### PR TITLE
Fix crash on ttl assumed as number re. mesecons

### DIFF
--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -14,8 +14,6 @@ local function door_signal_overwrite(name)
 		action_on  =  function (pos,node,ttl)
 			if type(ttl) == "number" then
 				if ttl<0 then return end
-			else
-				return
 			end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -12,6 +12,7 @@ local function door_signal_overwrite(name)
 	-- this will make door toggle whenever its used
 	table2.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
+			if type(ttl) ~= "number" then ttl = 1 end
 			if ttl<0 then return end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -15,7 +15,7 @@ local function door_signal_overwrite(name)
 			if type(ttl) == "number" then
 				if ttl<0 then return end
 			else
-				return end
+				return
 			end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -14,6 +14,8 @@ local function door_signal_overwrite(name)
 		action_on  =  function (pos,node,ttl)
 			if type(ttl) == "number" then
 				if ttl<0 then return end
+			else
+				return end
 			end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -12,9 +12,7 @@ local function door_signal_overwrite(name)
 	-- this will make door toggle whenever its used
 	table2.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
-			if type(ttl) == "number" then
-				if ttl<0 then return end
-			end
+			if type(ttl)~="number" then ttl = 1 end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player
 			local clicker = {}; 

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -12,8 +12,9 @@ local function door_signal_overwrite(name)
 	-- this will make door toggle whenever its used
 	table2.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
-			if type(ttl) ~= "number" then ttl = 1 end
-			if ttl<0 then return end
+			if type(ttl) == "number" then
+				if ttl<0 then return end
+			end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player
 			local clicker = {}; 

--- a/mesecon_doors.lua
+++ b/mesecon_doors.lua
@@ -13,6 +13,7 @@ local function door_signal_overwrite(name)
 	table2.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
 			if type(ttl)~="number" then ttl = 1 end
+			if ttl<0 then return end
 			local meta = minetest.get_meta(pos);local name = meta:get_string("doors_owner");
 			-- create virtual player
 			local clicker = {}; 

--- a/mesecon_lights.lua
+++ b/mesecon_lights.lua
@@ -14,9 +14,8 @@ local table = minetest.registered_nodes[name]; if not table then return end
 	
 	table2.mesecons = {effector = { -- action to toggle light off
 		action_off  =  function (pos,node,ttl)
-			if type(ttl) == "number" then
-				if ttl<0 then return end
-			end
+			if type(ttl)~="number" then ttl = 1 end
+			if ttl<0 then return end
 			minetest.swap_node(pos,{name = offname});
 		end
 		}
@@ -34,9 +33,8 @@ local table = minetest.registered_nodes[name]; if not table then return end
 	table3.light_source = 0; -- off block has light off
 	table3.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
-			if type(ttl) == "number" then
-				if ttl<0 then return end
-			end
+			if type(ttl)~="number" then ttl = 1 end
+			if ttl<0 then return end
 			minetest.swap_node(pos,{name = name});
 		end
 		}

--- a/mesecon_lights.lua
+++ b/mesecon_lights.lua
@@ -14,7 +14,9 @@ local table = minetest.registered_nodes[name]; if not table then return end
 	
 	table2.mesecons = {effector = { -- action to toggle light off
 		action_off  =  function (pos,node,ttl)
-			if ttl<0 then return end
+			if type(ttl) == "number" then
+				if ttl<0 then return end
+			end
 			minetest.swap_node(pos,{name = offname});
 		end
 		}
@@ -32,7 +34,9 @@ local table = minetest.registered_nodes[name]; if not table then return end
 	table3.light_source = 0; -- off block has light off
 	table3.mesecons = {effector = {
 		action_on  =  function (pos,node,ttl)
-			if ttl<0 then return end
+			if type(ttl) == "number" then
+				if ttl<0 then return end
+			end
 			minetest.swap_node(pos,{name = name});
 		end
 		}

--- a/mover.lua
+++ b/mover.lua
@@ -1300,7 +1300,7 @@ minetest.register_chatcommand("clockgen", { -- test: toggle machine running with
 	func = function(name, param)
 		local privs = minetest.get_player_privs(name);
 	--	if not privs.privs and name~="rnd" then return end
-		return end
+		if not privs.privs then return end
 		local player = minetest.get_player_by_name(name);
 		if basic_machines.clockgen == 0 then basic_machines.clockgen = 1 else basic_machines.clockgen = 0 end
 		minetest.chat_send_player(name, "#clockgen set to " .. basic_machines.clockgen);

--- a/mover.lua
+++ b/mover.lua
@@ -1299,7 +1299,8 @@ minetest.register_chatcommand("clockgen", { -- test: toggle machine running with
 	},
 	func = function(name, param)
 		local privs = minetest.get_player_privs(name);
-		if not privs.privs and name~="rnd" then return end
+	--	if not privs.privs and name~="rnd" then return end
+		return end
 		local player = minetest.get_player_by_name(name);
 		if basic_machines.clockgen == 0 then basic_machines.clockgen = 1 else basic_machines.clockgen = 0 end
 		minetest.chat_send_player(name, "#clockgen set to " .. basic_machines.clockgen);

--- a/mover.lua
+++ b/mover.lua
@@ -408,6 +408,7 @@ minetest.register_node("basic_machines:mover", {
 							if inv:room_for_item("main", stack) then
 								teleport_any = true;
 								inv:add_item("main", stack);
+								obj:setpos({x=0,y=0,z=0}); -- patch for dupe, might not be needed if future minetest object management is better
 							end
 							obj:remove();
 						end


### PR DESCRIPTION
It is being assumed that ttl is 1) defined and 2) is a number. Therefore when say, a pressure plate is used, Minetest crashes saying:

ERROR[Main]: ServerError: Runtime error from mod 'mesecons' in callback environment_Step(): ../basic_machines/mesecon_doors.lua:15: **attempt to compare table with number**

Remove this assumption and stop crashing minetest.

There are other instances of this bug throughout the mod, but I'm only focusing on mesecons.

Thanks also to @DonBatman