### PR TITLE
updated mover code

### DIFF
--- a/grinder.lua
+++ b/grinder.lua
@@ -8,6 +8,7 @@
 -- recipe list: [in] ={fuel cost, out, quantity of material required for processing}
 basic_machines.grinder_recipes = {
 	["default:stone"] = {2,"default:sand",1},
+	["default:desert_stone"] = {2,"default:desert_sand 4",1},
 	["default:cobble"] = {1,"default:gravel",1},
 	["default:gravel"] = {0.5,"default:dirt",1},
 	["default:dirt"] = {0.5,"default:clay_lump 4",1},

--- a/mover.lua
+++ b/mover.lua
@@ -49,8 +49,8 @@ basic_machines.hardness["mese_crystals:mese_crystal_ore4"] = 10;
 
 
 -- define which nodes are dug up completely, like a tree
-basic_machines.dig_up_table = {["default:cactus"]=true,["default:tree"]=true,["default:jungletree"]=true,["default:pinetree"]=true,
-["default:acacia_tree"]=true,["default:papyrus"]=true};
+basic_machines.dig_up_table = {["default:cactus"]=true,["default:tree"]=true,["default:jungletree"]=true,["default:pine_tree"]=true,
+["default:acacia_tree"]=true,["default:aspen_tree"]=true,["default:papyrus"]=true};
 				
 -- set up nodes for harvest when digging: [nodename] = {what remains after harvest, harvest result}
 basic_machines.harvest_table = {

--- a/mover.lua
+++ b/mover.lua
@@ -795,8 +795,11 @@ minetest.register_node("basic_machines:mover", {
 			if type(ttl)~="number" then ttl = 1 end
 			local meta = minetest.get_meta(pos);
 			local mreverse = meta:get_int("reverse");
-			if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
-			meta:set_int("reverse",mreverse);			
+			local mode = meta:get_string("mode");
+			if mode ~= "dig" then
+			  if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
+			  meta:set_int("reverse",mreverse);			
+			end
 		end
 		
 		

--- a/mover.lua
+++ b/mover.lua
@@ -703,7 +703,9 @@ minetest.register_node("basic_machines:mover", {
 				
 				if dig_up == true then -- dig up to 16 nodes
 					
-					local r = 1; if node1.name == "default:cactus" or node1.name == "default:papyrus" then r = 0 end
+					local r = 1; 
+					if node1.name == "default:cactus" or node1.name == "default:papyrus" then r = 0 end
+					if node1.name == "default:acacia_tree" then r = 2 end -- acacia trees grow wider than others
 					
 					local positions = minetest.find_nodes_in_area( --
 					{x=pos1.x-r, y=pos1.y, z=pos1.z-r},
@@ -796,7 +798,7 @@ minetest.register_node("basic_machines:mover", {
 			local meta = minetest.get_meta(pos);
 			local mreverse = meta:get_int("reverse");
 			local mode = meta:get_string("mode");
-			if mode ~= "dig" then
+			if mode ~= "dig" then -- reverse switching is not very helpful when auto harvest trees for example
 			  if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
 			  meta:set_int("reverse",mreverse);			
 			end


### PR DESCRIPTION
there was a typo in mover.lua when trying to harvest tree in dig mode:

it is default:pine_tree not default:pinetree
also I added default:aspen_tree

radius to dig acacia_tree was too small, changed from 1 to 2

After digging a tree the REVERSE field in mover changed from 0 to 1. why ?
I turned it off when mover is in dig mode, but maybe you know better
 