### PR TITLE
security checks before  dig machines

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -338,9 +338,21 @@ minetest.register_node("basic_machines:autocrafter", {
 		if type(ttl)~="number" then ttl = 1 end
 		if ttl<0 then return end -- machines_TTL prevents infinite recursion
 		run_autocrafter(pos, craft_time);
-	end
+	end,
+	
+		can_dig = function(pos)
+			local meta = minetest.get_meta(pos);
+			local inv = meta:get_inventory();
+			
+			if not (inv:is_empty("src")) or not (inv:is_empty("dst")) then return false end -- all inv must be empty to be dug
+			
+			return true
+			
+		end
+
 	}
 	}
+	
 	--on_timer = run_autocrafter -- rnd
 })
 

--- a/constructor.lua
+++ b/constructor.lua
@@ -204,6 +204,17 @@ minetest.register_node("basic_machines:constructor", {
 		
 		constructor_update_meta(pos);
 	end,
+	
+		can_dig = function(pos)
+			local meta = minetest.get_meta(pos);
+			local inv = meta:get_inventory();
+			
+			if not (inv:is_empty("main"))  then return false end -- main inv must be empty to be dug
+			
+			return true
+			
+		end
+
 
 })
 

--- a/enviro.lua
+++ b/enviro.lua
@@ -206,6 +206,12 @@ minetest.register_node("basic_machines:enviro", {
 		if meta:get_string("owner")~=player:get_player_name() and not privs.privs then return 0 end
 		return stack:get_count();
 	end,
+		
+	can_dig = function(pos, player) -- dont dig if fuel is inside, cause it will be destroyed
+		local meta = minetest.get_meta(pos);
+		local inv = meta:get_inventory();
+		return inv:is_empty("fuel")
+	end,
 	
 })
 

--- a/grinder.lua
+++ b/grinder.lua
@@ -218,6 +218,16 @@ minetest.register_node("basic_machines:grinder", {
 		end
 		grinder_update_meta(pos);
 	end,
+	
+	can_dig = function(pos)
+			local meta = minetest.get_meta(pos);
+			local inv = meta:get_inventory();
+			
+			if not (inv:is_empty("fuel")) or not (inv:is_empty("src")) or not (inv:is_empty("dst")) then return false end -- all inv must be empty to be dug
+			
+			return true
+			
+		end
 
 })
 

--- a/grinder.lua
+++ b/grinder.lua
@@ -8,6 +8,7 @@
 -- recipe list: [in] ={fuel cost, out, quantity of material required for processing}
 basic_machines.grinder_recipes = {
 	["default:stone"] = {2,"default:sand",1},
+	["default:desert_stone"] = {2,"default:desert_sand 4",1},
 	["default:cobble"] = {1,"default:gravel",1},
 	["default:gravel"] = {0.5,"default:dirt",1},
 	["default:dirt"] = {0.5,"default:clay_lump 4",1},

--- a/init.lua
+++ b/init.lua
@@ -19,6 +19,7 @@
 basic_machines = {};
 
 
+
 dofile(minetest.get_modpath("basic_machines").."/mark.lua") -- used for markings, borrowed and adapted from worldedit mod
 dofile(minetest.get_modpath("basic_machines").."/mover.lua") -- mover, detector, keypad, distributor
 dofile(minetest.get_modpath("basic_machines").."/technic_power.lua") -- technic power for mover

--- a/mover.lua
+++ b/mover.lua
@@ -49,8 +49,8 @@ basic_machines.hardness["mese_crystals:mese_crystal_ore4"] = 10;
 
 
 -- define which nodes are dug up completely, like a tree
-basic_machines.dig_up_table = {["default:cactus"]=true,["default:tree"]=true,["default:jungletree"]=true,["default:pinetree"]=true,
-["default:acacia_tree"]=true,["default:papyrus"]=true};
+basic_machines.dig_up_table = {["default:cactus"]=true,["default:tree"]=true,["default:jungletree"]=true,["default:pine_tree"]=true,
+["default:acacia_tree"]=true,["default:aspen_tree"]=true,["default:papyrus"]=true};
 				
 -- set up nodes for harvest when digging: [nodename] = {what remains after harvest, harvest result}
 basic_machines.harvest_table = {

--- a/mover.lua
+++ b/mover.lua
@@ -795,8 +795,11 @@ minetest.register_node("basic_machines:mover", {
 			if type(ttl)~="number" then ttl = 1 end
 			local meta = minetest.get_meta(pos);
 			local mreverse = meta:get_int("reverse");
-			if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
-			meta:set_int("reverse",mreverse);			
+			local mode = meta:get_string("mode");
+			if mode ~= "dig" then
+			  if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
+			  meta:set_int("reverse",mreverse);			
+			end
 		end
 		
 		

--- a/mover.lua
+++ b/mover.lua
@@ -703,7 +703,9 @@ minetest.register_node("basic_machines:mover", {
 				
 				if dig_up == true then -- dig up to 16 nodes
 					
-					local r = 1; if node1.name == "default:cactus" or node1.name == "default:papyrus" then r = 0 end
+					local r = 1; 
+					if node1.name == "default:cactus" or node1.name == "default:papyrus" then r = 0 end
+					if node1.name == "default:acacia_tree" then r = 2 end -- acacia trees grow wider than others
 					
 					local positions = minetest.find_nodes_in_area( --
 					{x=pos1.x-r, y=pos1.y, z=pos1.z-r},
@@ -796,7 +798,7 @@ minetest.register_node("basic_machines:mover", {
 			local meta = minetest.get_meta(pos);
 			local mreverse = meta:get_int("reverse");
 			local mode = meta:get_string("mode");
-			if mode ~= "dig" then
+			if mode ~= "dig" then -- reverse switching is not very helpful when auto harvest trees for example
 			  if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
 			  meta:set_int("reverse",mreverse);			
 			end

--- a/mover.lua
+++ b/mover.lua
@@ -282,7 +282,7 @@ minetest.register_node("basic_machines:mover", {
 	can_dig = function(pos, player) -- dont dig if upgrades inside, cause they will be destroyed
 		local meta = minetest.get_meta(pos);
 		local inv = meta:get_inventory();
-		return not(inv:contains_item("upgrade", ItemStack({name="default:mese"})));
+		return inv:is_empty("upgrade")
 	end,
 	
 	

--- a/recycler.lua
+++ b/recycler.lua
@@ -144,7 +144,7 @@ local recycler_update_meta = function(pos)
 	local meta = minetest.get_meta(pos)
 	local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z 
 	local form  = 
-		"size[8,8]"..  -- width, height
+		"size[8,8]"..  -- width, heightinv:get_stack
 		--"size[6,10]"..  -- width, height
 		"label[0,0;IN] label[1,0;OUT] label[0,2;FUEL] "..
 		"list["..list_name..";src;0.,0.5;1,1;]"..
@@ -229,6 +229,17 @@ minetest.register_node("basic_machines:recycler", {
 		meta:set_string("node",""); -- this will force to reread recipe on next use
 		recycler_update_meta(pos);
 	end,
+	
+	can_dig = function(pos)
+	
+			local meta = minetest.get_meta(pos);
+			local inv = meta:get_inventory();
+			
+			if not (inv:is_empty("fuel")) or not (inv:is_empty("src")) or not (inv:is_empty("dst")) then return false end -- all inv must be empty to be dug
+		  			
+			return true
+			
+		end
 
 })
 

--- a/technic_power.lua
+++ b/technic_power.lua
@@ -268,7 +268,12 @@ minetest.register_node("basic_machines:battery_0", {
 		
 		can_dig = function(pos)
 			local meta = minetest.get_meta(pos);
-			if meta:get_int("upgrade")~=0 then return false else return true end
+			local inv = meta:get_inventory();
+			
+			if not (inv:is_empty("fuel")) or not (inv:is_empty("upgrade")) then return false end -- fuel AND upgrade inv must be empty to be dug
+			
+			return true
+			
 		end
 	
 })
@@ -386,7 +391,12 @@ minetest.register_node("basic_machines:generator", {
 		
 		can_dig = function(pos)
 			local meta = minetest.get_meta(pos);
-			if meta:get_int("upgrade")~=0 then return false else return true end
+			local inv = meta:get_inventory();
+			
+			if not inv:is_empty("upgrade") then return false end  -- fuel inv is not so important as generator generates it
+			
+			return true
+			
 		end
 	
 })


### PR DESCRIPTION
many players complained loss of upgrades and other stuff when (accidently) dug machines which
inventories have not been empty.

That is not possible anymore. Machines can't be dug if there is something still inside. Only generator fuel inv is not being checked

