### PR TITLE
Remove nodeupdate usage

### DIFF
--- a/mover.lua
+++ b/mover.lua
@@ -798,7 +798,7 @@ minetest.register_node("basic_machines:mover", {
 			end
 		end 
 		if not(source_chest) and not(harvest) then
-			if dig then nodeupdate(pos1) end
+			if dig then minetest.check_for_falling(pos1) end
 			minetest.set_node(pos1, {name = "air"});
 			end
 		end,


### PR DESCRIPTION
Seems deprecated in 5.0.0.
This should fix movers in dig mode causing internal server errors