### PR TITLE
fix crash when trying to use a digger for multiple items

### DIFF
--- a/mover.lua
+++ b/mover.lua
@@ -56,7 +56,7 @@ basic_machines.hardness["mese_crystals:mese_crystal_ore4"] = 10;
 -- define which nodes are dug up completely, like a tree
 basic_machines.dig_up_table = {["default:cactus"]=true,["default:tree"]=true,["default:jungletree"]=true,["default:pine_tree"]=true,
 ["default:acacia_tree"]=true,["default:aspen_tree"]=true,["default:papyrus"]=true};
-				
+
 -- set up nodes for harvest when digging: [nodename] = {what remains after harvest, harvest result}
 basic_machines.harvest_table = {
 ["mese_crystals:mese_crystal_ore4"] = {"mese_crystals:mese_crystal_ore1", "default:mese_crystal 3"}, -- harvesting mese crystals
@@ -131,59 +131,59 @@ local machines_operations = basic_machines.machines_operations
 local machines_TTL = basic_machines.machines_TTL
 
 
-local punchset = {}; 
+local punchset = {};
 
-minetest.register_on_joinplayer(function(player) 
+minetest.register_on_joinplayer(function(player)
 	local name = player:get_player_name(); if name == nil then return end
 	punchset[name] = {};
 	punchset[name].state = 0;
 end)
 
 local get_mover_form = function(pos,player)
-	
+
 	if not player then return end
 	local meta = minetest.get_meta(pos);
 	local x0,y0,z0,x1,y1,z1,x2,y2,z2,prefer,mode,mreverse;
-	
+
 	x0=meta:get_int("x0");y0=meta:get_int("y0");z0=meta:get_int("z0");x1=meta:get_int("x1");y1=meta:get_int("y1");z1=meta:get_int("z1");x2=meta:get_int("x2");y2=meta:get_int("y2");z2=meta:get_int("z2");
 
 	machines.pos1[player:get_player_name()] = {x=pos.x+x0,y=pos.y+y0,z=pos.z+z0};machines.mark_pos1(player:get_player_name()) -- mark pos1
 	machines.pos11[player:get_player_name()] = {x=pos.x+x1,y=pos.y+y1,z=pos.z+z1};machines.mark_pos11(player:get_player_name()) -- mark pos11
 	machines.pos2[player:get_player_name()] = {x=pos.x+x2,y=pos.y+y2,z=pos.z+z2};machines.mark_pos2(player:get_player_name()) -- mark pos2
-	
+
 	prefer = meta:get_string("prefer");
 	local mreverse = meta:get_int("reverse");
 	local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z
 	local mode_list = {["normal"]=1,["dig"]=2, ["drop"]=3, ["object"]=4, ["inventory"]=5, ["transport"]=6};
-	
+
 	local mode_string = meta:get_string("mode") or "";
-	
+
 	local meta1 = minetest.get_meta({x=pos.x+x0,y=pos.y+y0,z=pos.z+z0}); -- source meta
 	local meta2 = minetest.get_meta({x=pos.x+x2,y=pos.y+y2,z=pos.z+z2}); -- target meta
-	
-	
+
+
 	local inv1=1; local inv2=1;
 	local inv1m = meta:get_string("inv1");local inv2m = meta:get_string("inv2");
-	
+
 	local list1 = meta1:get_inventory():get_lists(); local inv_list1 = ""; local j;
 	j=1; -- stupid dropdown requires item index but returns string on receive so we have to find index.. grrr, one other solution: invert the table: key <-> value
-	
-	
-	for i in pairs( list1) do 
-		inv_list1 = inv_list1 .. i .. ","; 
+
+
+	for i in pairs( list1) do
+		inv_list1 = inv_list1 .. i .. ",";
 		if i == inv1m then inv1=j end; j=j+1;
 	end
 	local list2 = meta2:get_inventory():get_lists(); local inv_list2 = "";
 	j=1;
-	for i in pairs( list2) do 
+	for i in pairs( list2) do
 		inv_list2 = inv_list2 .. i .. ",";
-		if i == inv2m then inv2=j; end; j=j+1; 
+		if i == inv2m then inv2=j; end; j=j+1;
 	end
 
 	local upgrade = meta:get_float("upgrade"); if upgrade>0 then upgrade = upgrade - 1 end
 	local seltab = meta:get_int("seltab");
 	local form;
-	
+
 	if seltab == 1 then -- MODE --
 		local mode_description = {
 			["normal"] = "This will move blocks as they are - without change.",
@@ -193,30 +193,30 @@ local get_mover_form = function(pos,player)
 			["inventory"] = "This will move items from inventory of any block at source position to any inventory of block at target position",
 			["transport"] = "This will move all blocks at source area to new area starting at target position. This mode preserves all inventories and other metadata",
 		};
-		
+
 		local text = mode_description[mode_string] or "description";
 		local mode_list = {["normal"]=1,["dig"]=2, ["drop"]=3, ["object"]=4, ["inventory"]=5, ["transport"]=6};
 		mode = mode_list[mode_string] or 1;
-		
+
 		form = "size[8,8.25]" ..  -- width, height
 		--"size[6,10]" ..  -- width, height
 		"tabheader[0,0;tabs;MODE OF OPERATION,WHERE TO MOVE;".. seltab .. ";true;true]"..
 		"label[0.,0;MODE selection]".."button[3,0.25;1,1;help;help]"..
 		"dropdown[0.,0.35;3,1;mode;normal,dig,drop,object,inventory,transport;".. mode .."]"..
 		"textarea[0.25,1.25;8,2.;description;;".. text.."]"..
-		
+
 		"field[0.25,3.5;3,1;prefer;FILTER;"..prefer.."]"..
-		
+
 		"list[nodemeta:"..pos.x..','..pos.y..','..pos.z ..";filter;3,3.4;1,1;]"..
-		"list[nodemeta:"..pos.x..','..pos.y..','..pos.z ..";upgrade;5,3.4;1,1;]".."label[4,3;UPGRADE LVL ".. upgrade .."]" .. 
+		"list[nodemeta:"..pos.x..','..pos.y..','..pos.z ..";upgrade;5,3.4;1,1;]".."label[4,3;UPGRADE LVL ".. upgrade .."]" ..
 		"list[current_player;main;0,4.5;8,4;]"..
 		"listring[nodemeta:"..pos.x..','..pos.y..','..pos.z ..";upgrade]"..
 		"listring[current_player;main]"..
 		"listring[nodemeta:"..pos.x..','..pos.y..','..pos.z ..";filter]"..
 		"listring[current_player;main] button_exit[5,0.25;1,1;OK;OK]"
-		
+
 	else -- POSITIONS
-		
+
 		local inventory_list1,inventory_list2;
 		if mode_string == "inventory" then
 			inventory_list1 = "label[4.5,0.25;source inventory] dropdown[4.5,0.75;1.5,1;inv1;".. inv_list1 ..";" .. inv1 .."]"
@@ -224,21 +224,21 @@ local get_mover_form = function(pos,player)
 		else
 			inventory_list1 = ""; inventory_list2 = ""
 		end
-		
+
 
 		form = "size[8,8.25]" ..  -- width, height
 		--"size[6,10]" ..  -- width, height
 		"tabheader[0,0;tabs;MODE OF OPERATION,WHERE TO MOVE;".. seltab .. ";true;true]"..
-		
+
 		"label[0.,0;" .. minetest.colorize("lawngreen","INPUT AREA - mover will dig here").."]"..
 		"field[0.25,1.;1,1;x0;source1;"..x0.."] field[1.25,1.;1,1;y0;;"..y0.."] field[2.25,1.;1,1;z0;;"..z0.."]"..
 		"image[3,0.75;1,1;machines_pos1.png]"..
 		inventory_list1..
 		"field[0.25,2;1,1;x1;source2;"..x1.."] field[1.25,2;1,1;y1;;"..y1.."] field[2.25,2;1,1;z1;;"..z1.."]"..
 		"image[3,1.75;1,1;machines_pos11.png]"..
-		
+
 		"label[0.,2.75;" .. minetest.colorize("red","TARGET POSITION - mover will move to here").."]"..
-		
+
 		"field[0.25,3.75;1,1;x2;Target;"..x2.."] field[1.25,3.75;1,1;y2;;"..y2.."] field[2.25,3.75;1,1;z2;;"..z2.."]"..
 		"image[3,3.5;1,1;machines_pos2.png]"..
 		inventory_list2 ..
@@ -258,11 +258,11 @@ local find_and_connect_battery = function(pos)
 			{x=pos.x-r, y=pos.y-r, z=pos.z-r},
 			{x=pos.x+r, y=pos.y+r, z=pos.z+r},
 			"basic_machines:battery_" .. i )
-		if #positions>0 then 
+		if #positions>0 then
 			local meta = minetest.get_meta(pos);
 			local fpos = positions[1] ;
 			meta:set_int("batx", fpos.x);meta:set_int("baty", fpos.y); meta:set_int("batz", fpos.z)
-			return fpos 
+			return fpos
 		end -- pick first battery we found
 	end
 	return nil
@@ -291,42 +291,42 @@ minetest.register_node("basic_machines:mover", {
 		meta:set_string("mode", "normal");
 		meta:set_float("upgrade", 1);
 		meta:set_int("seltab",1);
-		
+
 		local privs = minetest.get_player_privs(placer:get_player_name());
 		if privs.privs then meta:set_float("upgrade", -1); end -- means operation will be for free
-		
-		local inv = meta:get_inventory();inv:set_size("upgrade", 1*1);inv:set_size("filter", 1*1) 
+
+		local inv = meta:get_inventory();inv:set_size("upgrade", 1*1);inv:set_size("filter", 1*1)
 		local name = placer:get_player_name(); punchset[name].state = 0
-		
-		
+
+
 		local text = "This machine can move anything. General idea is the following : \n\n"..
 		"First you need to define rectangle box work area (larger area, where it takes from, defined by source1/source2 which are two number 1 boxes that appear in world) and target position (where it puts, marked by one number 2 box) by punching mover then following CHAT instructions exactly.\n\n"..
 		"CHECK why it doesnt work: 1. did you click OK in mover after changing setting 2. does it have battery, 3. does battery have enough fuel 4. did you set filter for taking out of chest?\n\n"..
 		"IMPORTANT: Please read the help button inside machine before first use.";
-		
+
 			local form = "size [7.5,5.5] textarea[0,0.1;8,7;help;MOVER INTRODUCTION;".. text.."]"
 			minetest.show_formspec(name, "basic_machines:intro_mover", form)
-		
-		
-		
+
+
+
 	end,
-	
+
 	can_dig = function(pos, player) -- dont dig if upgrades inside, cause they will be destroyed
 		local meta = minetest.get_meta(pos);
 		local inv = meta:get_inventory();
 		return inv:is_empty("upgrade")
 	end,
-	
-	
+
+
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
 		local privs = minetest.get_player_privs(player:get_player_name());
 		--local cant_build = minetest.is_protected(pos,player:get_player_name());
 		--if not privs.privs and cant_build then return end -- only ppl sharing protection can setup
-		
+
 		local form = get_mover_form(pos,player)
 		minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
 	end,
-	
+
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		if minetest.is_protected(pos,player:get_player_name()) then return end
 		if listname == "filter" then
@@ -338,13 +338,13 @@ minetest.register_node("basic_machines:mover", {
 			minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
 			return 1;
 		end
-		
+
 		if listname == "upgrade" then
 			-- update upgrades
 			local meta = minetest.get_meta(pos);
 			local upgrade = 0;
 			local inv = meta:get_inventory();
-			
+
 			local upgrade_name = "default:mese";
 			if meta:get_int("elevator")==1 then upgrade_name = "default:diamondblock" end
 			if stack:get_name() == upgrade_name then
@@ -353,17 +353,17 @@ minetest.register_node("basic_machines:mover", {
 				upgrade = upgrade + stack:get_count();
 				if upgrade > 10 then upgrade = 10 end -- not more than 10
 				meta:set_float("upgrade",upgrade+1);
-			
+
 				local form = get_mover_form(pos,player)
 				minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
-			end	
-			
-			
+			end
+
+
 		end
-		
+
 		return stack:get_count();
 	end,
-	
+
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		if minetest.is_protected(pos,player:get_player_name()) then return end
 		local meta = minetest.get_meta(pos);
@@ -372,18 +372,18 @@ minetest.register_node("basic_machines:mover", {
 		minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
 		return stack:get_count();
 	end,
-	
+
 	effector = {
-		action_on = function (pos, node,ttl) 
-		
+		action_on = function (pos, node,ttl)
+
 			if type(ttl)~="number" then ttl = 1 end
 			local meta = minetest.get_meta(pos);
 			local fuel = meta:get_float("fuel");
 
-			
+
 			local x0=meta:get_int("x0"); local y0=meta:get_int("y0"); local z0=meta:get_int("z0");
 			local x2=meta:get_int("x2"); local y2=meta:get_int("y2"); local z2=meta:get_int("z2");
-			
+
 			local mode = meta:get_string("mode");
 			local mreverse = meta:get_int("reverse")
 			local pos1 = {x=x0+pos.x,y=y0+pos.y,z=z0+pos.z}; -- where to take from
@@ -391,19 +391,19 @@ minetest.register_node("basic_machines:mover", {
 
 			local pc = meta:get_int("pc"); local dim = meta:get_int("dim");	pc = (pc+1) % dim;meta:set_int("pc",pc) -- cycle position
 			local x1=meta:get_int("x1")-x0+1;local y1=meta:get_int("y1")-y0+1;local z1=meta:get_int("z1")-z0+1; -- get dimensions
-			
+
 			--pc = z*a*b+x*b+y, from x,y,z to pc
 			-- set current input position
 			pos1.y = y0 + (pc % y1); pc = (pc - (pc % y1))/y1;
 			pos1.x = x0 + (pc % x1); pc = (pc - (pc % x1))/x1;
 			pos1.z = z0 + pc;
 			pos1.x = pos.x+pos1.x;pos1.y = pos.y+pos1.y;pos1.z = pos.z+pos1.z;
-			
+
 			-- special modes that use its own source/target positions:
 			if mode == "transport" and mreverse<2 then
 				pos2 = {x=meta:get_int("x2")-x0+pos1.x,y=meta:get_int("y2")-y0+pos1.y,z=meta:get_int("z2")-z0+pos1.z}; -- translation from pos1
 			end
-			
+
 			if mreverse ~= 0 and mreverse ~= 2 then -- reverse pos1, pos2
 				if mode == "object" then
 					x0 = pos2.x-pos.x; y0 = pos2.y-pos.y; z0 = pos2.z-pos.z;
@@ -414,63 +414,63 @@ minetest.register_node("basic_machines:mover", {
 					pos2 = {x=post.x,y=post.y,z=post.z};
 				end
 			end
-			
+
 
 			-- PROTECTION CHECK
 			local owner = meta:get_string("owner");
 			if (minetest.is_protected(pos1, owner) or minetest.is_protected(pos2, owner)) and mode~="object" then
 				meta:set_string("infotext", "Mover block. Protection fail. ")
-			return 
+			return
 			end
-			
+
 			local node1 = minetest.get_node(pos1);local node2 = minetest.get_node(pos2);
-			local prefer = meta:get_string("prefer"); 
-		
+			local prefer = meta:get_string("prefer");
+
 			-- FUEL COST: calculate
 			local dist = math.abs(pos2.x-pos1.x)+math.abs(pos2.y-pos1.y)+math.abs(pos2.z-pos1.z);
 			local hardness = basic_machines.hardness[node1.name];
 			-- no free teleports from machine blocks
 			if hardness == 0 and mode == "object" then hardness = 1 end
 			local fuel_cost = hardness or 1;
-			
+
 			local upgrade =  meta:get_float("upgrade") or 1;
-			
+
 			-- taking items from chests/inventory move
 			if node1.name == "default:chest_locked" or mode == "inventory" then fuel_cost = basic_machines.hardness[prefer] or 1 end;
-			
+
 			fuel_cost=fuel_cost*dist/machines_operations; -- machines_operations=10 by default, so 10 basic operations possible with 1 coal
-			if mode == "object" then  
-				fuel_cost=fuel_cost*0.1; 
+			if mode == "object" then
+				fuel_cost=fuel_cost*0.1;
 				if (x2 == 0 and y2 == 0) or (x2==0 and z2==0) or (y2==0 and z2 == 0) then -- check if elevator mode
 					local requirement = math.floor((math.abs(pos2.x-pos.x)+math.abs(pos2.y-pos.y)+math.abs(pos2.z-pos.z))/100)+1;
 					if upgrade-1<requirement then
 						meta:set_string("infotext","MOVER: Elevator error. Need at least "..requirement .. " diamond block(s) in upgrade (1 for every 100 distance). ");
 						return;
 					end
-					fuel_cost = 0 
+					fuel_cost = 0
 				end
-			elseif mode == "inventory" then 
+			elseif mode == "inventory" then
 				fuel_cost=fuel_cost*0.1;
 			end
-			
+
 			fuel_cost = fuel_cost/upgrade; -- upgrade decreases fuel cost
 			if upgrade == -1 then fuel_cost = 0 end -- free operation for admin
-			
-		
+
+
 			-- FUEL OPERATIONS
 			if fuel<fuel_cost then -- needs fuel to operate, find nearby battery
-				
+
 				local found_fuel = 0;
-				
+
 				-- cached battery position
 				local fpos = {x=meta:get_int("batx"), y=meta:get_int("baty"), z=meta:get_int("batz")};
-				
+
 				-- check battery for power
-		
+
 				local power_draw = fuel_cost;
 				if power_draw<1 then power_draw = 1 end -- at least 10 one block operations with 1 refuel
-				local supply = basic_machines.check_power(fpos, power_draw); 
-				
+				local supply = basic_machines.check_power(fpos, power_draw);
+
 				if supply>0 then
 					found_fuel=supply;
 				elseif supply<0 then -- no battery at target location, try to find it!
@@ -480,26 +480,26 @@ minetest.register_node("basic_machines:mover", {
 						minetest.sound_play("default_cool_lava", {pos=pos,gain=1.0,max_hear_distance = 8,})
 						return
 					end
-					
+
 				end
-				
+
 				if found_fuel~=0 then
 					fuel = fuel+found_fuel;
 					meta:set_float("fuel", fuel);
 					meta:set_string("infotext", "Mover block refueled. Fuel ".. fuel);
-				
+
 				end
-				
-			end 
-			
-			if fuel < fuel_cost then 
-				meta:set_string("infotext", "Mover block. Energy ".. fuel ..", needed energy " .. fuel_cost .. ". Put nonempty battery next to mover."); 
-				return  
+
 			end
-		
-				
+
+			if fuel < fuel_cost then
+				meta:set_string("infotext", "Mover block. Energy ".. fuel ..", needed energy " .. fuel_cost .. ". Put nonempty battery next to mover.");
+				return
+			end
+
+
 		if mode == "object" then -- teleport objects and return
-			
+
 			-- if target is chest put items in it
 			local target_chest = false
 			if node2.name == "default:chest" or node2.name == "default:chest_locked" then
@@ -507,18 +507,18 @@ minetest.register_node("basic_machines:mover", {
 			end
 			local r = math.max(math.abs(x1),math.abs(y1),math.abs(z1)); r = math.min(r,10);
 			local teleport_any = false;
-			
+
 			if target_chest then -- put objects in target chest
 				local cmeta = minetest.get_meta(pos2);
 				local inv = cmeta:get_inventory();
-								
+
 				for _,obj in pairs(minetest.get_objects_inside_radius({x=x0+pos.x,y=y0+pos.y,z=z0+pos.z}, r)) do
-					local lua_entity = obj:get_luaentity() 
+					local lua_entity = obj:get_luaentity()
 					if not obj:is_player() and lua_entity and lua_entity.itemstring ~= "" then
 						local detected_obj = lua_entity.itemstring or ""
-						if not basic_machines.no_teleport_table[detected_obj] and (prefer=="" or prefer==detected_obj)  then -- object on no teleport list 
+						if not basic_machines.no_teleport_table[detected_obj] and (prefer=="" or prefer==detected_obj)  then -- object on no teleport list
 							-- put item in chest
-							local stack = ItemStack(lua_entity.itemstring) 
+							local stack = ItemStack(lua_entity.itemstring)
 							if inv:room_for_item("main", stack) then
 								teleport_any = true;
 								inv:add_item("main", stack);
@@ -535,7 +535,7 @@ minetest.register_node("basic_machines:mover", {
 				end
 				return
 			end
-			
+
 			local times = tonumber(prefer) or 0; if times > 20 then times = 20 elseif times<0.2 then times = 0 end
 			local velocityv;
 			if times~=0 then
@@ -546,9 +546,9 @@ minetest.register_node("basic_machines:mover", {
 				if vv ~= 0 then vv=velocitys/vv else vv =  0 end;
 				velocityv.x = velocityv.x * vv;	velocityv.y = velocityv.y * vv;	velocityv.z = velocityv.z* vv
 			end
-			
+
 			--minetest.chat_send_all(" times ".. times .. " v " .. minetest.pos_to_string(velocityv));
-			
+
 			-- move objects to another location
 			local finalsound = true;
 			for _,obj in pairs(minetest.get_objects_inside_radius({x=x0+pos.x,y=y0+pos.y,z=z0+pos.z}, r)) do
@@ -558,16 +558,16 @@ minetest.register_node("basic_machines:mover", {
 						teleport_any = true;
 					end
 				else
-				
+
 					local lua_entity = obj:get_luaentity();
-					local detected_obj = lua_entity.name or "" 
-					if not basic_machines.no_teleport_table[detected_obj] then -- object on no teleport list 
+					local detected_obj = lua_entity.name or ""
+					if not basic_machines.no_teleport_table[detected_obj] then -- object on no teleport list
 						if times > 0 then
 							local finalmove = true;
 							-- move objects with set velocity in target direction
 							obj:setvelocity(velocityv);
 							if obj:get_luaentity() then -- interaction with objects like carts
-								if lua_entity.name then 
+								if lua_entity.name then
 									if lua_entity.name == "basic_machines:ball" then -- move balls for free
 										lua_entity.velocity = {x=velocityv.x*times,y=velocityv.y*times,z=velocityv.z*times};
 										finalmove = false;
@@ -583,7 +583,7 @@ minetest.register_node("basic_machines:mover", {
 							end
 							--obj:setacceleration({x=0,y=0,z=0});
 							if finalmove then -- dont move objects like balls to destination after delay
-								minetest.after(times, function () if obj then obj:setvelocity({x=0,y=0,z=0}); obj:moveto(pos2, false) end end); 
+								minetest.after(times, function () if obj then obj:setvelocity({x=0,y=0,z=0}); obj:moveto(pos2, false) end end);
 							end
 						else
 								obj:moveto(pos2, false)
@@ -592,62 +592,62 @@ minetest.register_node("basic_machines:mover", {
 					teleport_any = true;
 				end
 			end
-				
+
 			if teleport_any then
 				fuel = fuel - fuel_cost; meta:set_float("fuel",fuel);
 				meta:set_string("infotext", "Mover block. Fuel "..fuel);
 				if finalsound then minetest.sound_play("tng_transporter1", {pos=pos2,gain=1.0,max_hear_distance = 8,}) end
 			end
-			
-			return 
+
+			return
 		end
-		
-		
+
+
 		local dig=false; if mode == "dig" then dig = true; end -- digs at target location
 		local drop = false; if mode == "drop" then drop = true; end -- drops node instead of placing it
 		local harvest = false; -- harvest mode for special nodes: mese crystals
-		
-		
+
+
 		-- decide what to do if source or target are chests
 		local source_chest=false; if string.find(node1.name,"default:chest") then source_chest=true end
 		if node1.name == "air" then return end -- nothing to move
-		
+
 		local target_chest = false
 		if node2.name == "default:chest" or node2.name == "default:chest_locked" then
 			target_chest = true
 		end
-		
+
 		if not(target_chest) and not(mode=="inventory") and minetest.get_node(pos2).name ~= "air" then return end -- do nothing if target nonempty and not chest
-		
+
 		local invName1="";local invName2="";
-		if mode == "inventory" then 
+		if mode == "inventory" then
 			invName1 = meta:get_string("inv1");invName2 = meta:get_string("inv2");
 			if mreverse == 1 then -- reverse inventory names too
 				local invNamet = invName1;invName1=invName2;invName2=invNamet;
 			end
 		end
-		
-		
+
+
 		-- inventory mode
 		if mode == "inventory" then
 					--if prefer == "" then meta:set_string("infotext", "Mover block. must set nodes to move (filter) in inventory mode."); return; end
-					
+
 					-- forbidden nodes to take from in inventory mode - to prevent abuses :
 					local limit_inventory = basic_machines.limit_inventory_table[node1.name]
 					if limit_inventory then
 						if limit_inventory == true or limit_inventory[invName1] then -- forbidden to take from this inventory
-							return 
-						end 
+							return
+						end
 					end
-					
+
 					local stack, meta1,inv1;
 					if prefer == "" then -- if prefer == "" then just pick one item from chest to transfer
 						meta1 = minetest.get_meta(pos1);
 						inv1 = meta1:get_inventory();
 						if inv1:is_empty(invName1) then return end -- nothing to move
-						
+
 						local size = inv1:get_size(invName1);
-						
+
 						local found = false;
 						for i = 1, size do -- find item to move in inventory
 							stack = inv1:get_stack(invName1, i);
@@ -662,12 +662,12 @@ minetest.register_node("basic_machines:mover", {
 					end
 					local meta2 = minetest.get_meta(pos2); local inv2 = meta2:get_inventory();
 					if not inv2:room_for_item(invName2, stack) then	return end
-					
+
 					-- add item to target inventory and remove item from source inventory
 					if prefer~="" then
 						meta1 = minetest.get_meta(pos1); inv1 = meta1:get_inventory();
 					end
-					
+
 					if inv1:contains_item(invName1, stack) then
 						inv2:add_item(invName2, stack);
 						inv1:remove_item(invName1, stack);
@@ -678,28 +678,28 @@ minetest.register_node("basic_machines:mover", {
 							return -- item not found in chest
 						end
 					end
-					
+
 					minetest.sound_play("chest_inventory_move", {pos=pos2,gain=1.0,max_hear_distance = 8,})
 					fuel = fuel - fuel_cost; meta:set_float("fuel",fuel);
 					meta:set_string("infotext", "Mover block. Fuel "..fuel);
 					return
 				end
-		
+
 		-- filtering
 		if prefer~="" then -- prefered node set
 			if prefer~=node1.name and not source_chest and mode ~= "inventory"  then return end -- only take prefered node or from chests/inventories
 			if source_chest then -- take stuff from chest
-				
+
 				local cmeta = minetest.get_meta(pos1);
 				local inv = cmeta:get_inventory();
 				local stack = ItemStack(prefer);
-				
+
 				if inv:contains_item("main", stack) then
 					inv:remove_item("main", stack);
-				else 
+				else
 					return
 				end
-				
+
 				if mreverse == 1 then -- planting mode: check if transform seed->plant is needed
 				if basic_machines.plant_table[prefer]~=nil then
 					prefer = basic_machines.plant_table[prefer];
@@ -707,60 +707,60 @@ minetest.register_node("basic_machines:mover", {
 			end
 			end
 
-			node1 = {}; node1.name = prefer; 
+			node1 = {}; node1.name = prefer;
 		end
-		
+
 		if (prefer == "" and source_chest) then return end -- doesnt know what to take out of chest/inventory
-		
-		
+
+
 		-- if target chest put in chest
 		if target_chest then
 			local cmeta = minetest.get_meta(pos2);
 			local inv = cmeta:get_inventory();
-						
+
 			-- dig tree or cactus
 			local count = 0;-- check for cactus or tree
 			local dig_up = false; -- digs up node as a tree
-			if dig then 
-				
+			if dig then
+
 				if not source_chest and basic_machines.dig_up_table[node1.name] then dig_up = true end
 				-- do we harvest the node?
-				if not source_chest then 
+				if not source_chest then
 					if basic_machines.harvest_table[node1.name]~=nil then
-						harvest = true 
+						harvest = true
 						local remains = basic_machines.harvest_table[node1.name][1];
 						local result = basic_machines.harvest_table[node1.name][2];
 						minetest.set_node(pos1,{name=remains});
 						inv:add_item("main",result);
 					end
 				end
-				
-				
+
+
 				if dig_up == true then -- dig up to 16 nodes
-					
-					local r = 1; 
+
+					local r = 1;
 					if node1.name == "default:cactus" or node1.name == "default:papyrus" then r = 0 end
 					if node1.name == "default:acacia_tree" then r = 2 end -- acacia trees grow wider than others
-					
+
 					local positions = minetest.find_nodes_in_area( --
 					{x=pos1.x-r, y=pos1.y, z=pos1.z-r},
 					{x=pos1.x+r, y=pos1.y+16, z=pos1.z+r},
 					node1.name)
-					
+
 					for _, pos3 in ipairs(positions) do
 						--if count>16 then break end
 						minetest.set_node(pos3,{name="air"}); count = count+1;
 					end
-					
+
 					inv:add_item("main", node1.name .. " " .. count-1);-- if tree or cactus was digged up
 				end
-				
-				
+
+
 				-- minetest drop code emulation
 				if not harvest then
 					local table = minetest.registered_items[node1.name];
 					if table~=nil then --put in chest
-						if table.drop~= nil then -- drop handling 
+						if table.drop~= nil then -- drop handling
 							if table.drop.items then
 							--handle drops better, emulation of drop code
 							local max_items = table.drop.max_items or 0;
@@ -770,64 +770,64 @@ minetest.register_node("basic_machines:mover", {
 								local drop = table.drop;
 								local i = 0;
 								for k,v in pairs(drop.items) do
-									if i > max_items then break end; i=i+1;								
+									if i > max_items then break end; i=i+1;
 									local rare = v.rarity or 1;
 									if math.random(1, rare)==1 then
 										node1={};node1.name = v.items[math.random(1,#v.items)]; -- pick item randomly from list
 										inv:add_item("main",node1.name);
-										
+
 									end
 								end
 							else
 								inv:add_item("main",table.drop);
-							end	
+							end
 						else
 							inv:add_item("main",node1.name);
 						end
 					end
 				end
-			
+
 			else -- if not dig just put it in
 			inv:add_item("main",node1.name);
 			end
-			
-		end	
-		
-		
+
+		end
+
+
 		minetest.sound_play("transporter", {pos=pos2,gain=1.0,max_hear_distance = 8,})
-		
+
 		if target_chest and source_chest then -- chest to chest transport has lower cost, *0.1
 			fuel_cost=fuel_cost*0.1;
 		end
-		
+
 		fuel = fuel - fuel_cost; meta:set_float("fuel",fuel);
 		meta:set_string("infotext", "Mover block. Fuel "..fuel);
 
-	
+
 		if mode == "transport" then -- transport nodes parallel as defined by source1 and target, clone with complete metadata
 			local meta1 = minetest.get_meta(pos1):to_table();
-			
+
 			minetest.set_node(pos2, minetest.get_node(pos1));
 			minetest.get_meta(pos2):from_table(meta1);
 			minetest.set_node(pos1,{name="air"});minetest.get_meta(pos1):from_table(nil)
 			return;
 		end
-		
+
 		-- REMOVE DIGGED NODE
 		if not(target_chest) then
 			if not drop then minetest.set_node(pos2, {name = node1.name}); end
-			if drop then 
+			if drop then
 				local stack = ItemStack(node1.name);
 				minetest.add_item(pos2,stack) -- drops it
 			end
-		end 
+		end
 		if not(source_chest) and not(harvest) then
 			if dig then check_for_falling(pos1) end -- pre 5.0.0 nodeupdate(pos1)
 			minetest.set_node(pos1, {name = "air"});
 			end
 		end,
-		
-	
+
+
 		action_off = function (pos, node,ttl) -- this toggles reverse option of mover
 			if type(ttl)~="number" then ttl = 1 end
 			local meta = minetest.get_meta(pos);
@@ -835,13 +835,13 @@ minetest.register_node("basic_machines:mover", {
 			local mode = meta:get_string("mode");
 			if mode ~= "dig" then -- reverse switching is not very helpful when auto harvest trees for example
 			  if mreverse == 1 then mreverse = 0 elseif mreverse==0 then mreverse = 1 end
-			  meta:set_int("reverse",mreverse);			
+			  meta:set_int("reverse",mreverse);
 			end
 		end
-		
-		
+
+
 	}
-	
+
 })
 
 -- anal retentive change in minetest 5.0.0 to minetest 5.1.0 changing unknown node warning into crash
@@ -851,6 +851,7 @@ local check_mover_filter = function(mode, filter, mreverse) -- mover input valid
 	if filter == "" then return true end -- allow clearing filter
 	if mode == "normal" or mode == "dig" then
 		local nodedef = minetest.registered_nodes[filter]
+		if string.find(filter," ") then return false end
 		if mreverse==1 and basic_machines.plant_table[filter] then return true end -- allow farming
 		if not nodedef then return false end
 	end
@@ -861,88 +862,88 @@ end
 -- KEYPAD --
 
 local function use_keypad(pos,ttl, again) -- position, time to live ( how many times can signal travel before vanishing to prevent infinite recursion ), do we want to activate again
-	
+
 	if ttl<0 then return end;
-	local meta = minetest.get_meta(pos);	
-	
+	local meta = minetest.get_meta(pos);
+
 	local t0 = meta:get_int("t");
-	local t1 = minetest.get_gametime(); 
+	local t1 = minetest.get_gametime();
 	local T = meta:get_int("T"); -- temperature
-	
+
 	if t0>t1-machines_minstep then -- activated before natural time
 		T=T+1;
 	else
-		if T>0 then 
-			T=T-1 
+		if T>0 then
+			T=T-1
 			if t1-t0>5 then T = 0 end
 		end
 	end
 	meta:set_int("T",T);
 	meta:set_int("t",t1); -- update last activation time
-	
+
 	if T > 2 then -- overheat
 			minetest.sound_play("default_cool_lava",{pos = pos, max_hear_distance = 16, gain = 0.25})
 			meta:set_string("infotext","overheat: temperature ".. T)
 			return
 	end
-	
-	
-	local name =  meta:get_string("owner"); 
+
+
+	local name =  meta:get_string("owner");
 	if minetest.is_protected(pos,name) then meta:set_string("infotext", "Protection fail. reset."); meta:set_int("count",0); return end
 	local count = meta:get_int("count") or 0; -- counts how many repeats left
-	
+
 	local repeating = meta:get_int("repeating");
-	
-	if repeating==1 and again~=1 then 
+
+	if repeating==1 and again~=1 then
 		-- stop it
 		meta:set_int("repeating",0);
 		meta:set_int("count", 0)
 		meta:set_int("T",4);
 		meta:set_string("infotext", "#KEYPAD: reseting. Punch again after 5s to activate")
 		return;
-	end	
-	
-	
-	
-	if count>0 then -- this is keypad repeating its activation
-		count = count - 1; meta:set_int("count",count);  
-	else
-		meta:set_int("repeating",0); 
-		--return 
 	end
-	
+
+
+
+	if count>0 then -- this is keypad repeating its activation
+		count = count - 1; meta:set_int("count",count);
+	else
+		meta:set_int("repeating",0);
+		--return
+	end
+
 	if count>=0 then
 		meta:set_string("infotext", "Keypad operation: ".. count .." cycles left")
 	else
 		meta:set_string("infotext", "Keypad operation: activation ".. -count)
 	end
-		
+
 	if count>0 then -- only trigger repeat if count on
 			if repeating == 0 then meta:set_int("repeating",1); end-- its repeating now
 			if basic_machines.clockgen==0 then return end
-			minetest.after(machines_timer, function() 
-				use_keypad(pos,machines_TTL,1) 
-			end )  
-		
+			minetest.after(machines_timer, function()
+				use_keypad(pos,machines_TTL,1)
+			end )
+
 	end
-	
+
 	local x0,y0,z0,mode;
 	x0=meta:get_int("x0");y0=meta:get_int("y0");z0=meta:get_int("z0");
 	x0=pos.x+x0;y0=pos.y+y0;z0=pos.z+z0;
 	mode = meta:get_int("mode");
 
 	-- pass the signal on to target, depending on mode
-	
+
 	local tpos = {x=x0,y=y0,z=z0}; -- target position
 	local node = minetest.get_node(tpos);if not node.name then return end -- error
-	local text = meta:get_string("text"); 
-	
+	local text = meta:get_string("text");
+
 	if text ~= "" then -- TEXT MODE; set text on target
 		if text == "@" then -- keyboard mode, set text from input
 			text = meta:get_string("input") or "";
 			meta:set_string("input",""); -- clear input again
 		end
-		
+
 		local bit = string.byte(text);
 		if bit == 33 then -- if text starts with !, then we send chat text to all nearby players, radius 5
 			text = string.sub(text,2) ; if not text or text == "" then return end
@@ -966,9 +967,9 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 				minetest.sound_play(string.sub(text,1,i-1), {pos=pos,gain=1.0,max_hear_distance = 16,pitch = pitch})
 			end
 		end
-		
+
 		local tmeta = minetest.get_meta(tpos);if not tmeta then return end
-		
+
 		if basic_machines.signs[node.name] then -- update text on signs with signs_lib
 			tmeta:set_string("infotext", text);
 			tmeta:set_string("text",text);
@@ -978,23 +979,23 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 				--signs_lib.update_sign(pos)
 				table.on_punch(tpos, node, nil); -- warning - this can cause problems if no signs_lib installed
 			end
-			
+
 			return
 		end
-		
+
 		-- target is keypad, special functions: @, % that output to target keypad text
 		if node.name == "basic_machines:keypad" then -- special modify of target keypad text and change its target
-			
+
 			x0=tmeta:get_int("x0");y0=tmeta:get_int("y0");z0=tmeta:get_int("z0");
 			x0=tpos.x+x0;y0=tpos.y+y0;z0=tpos.z+z0;
 			tpos = {x=x0,y=y0,z=z0};
-			
+
 			if string.byte(text) == 64 then -- target keypad's text starts with @ ( ascii code 64) -> character replacement
 				text = string.sub(text,2); if not text or text == "" then return end
 				--read words[j] from blocks above keypad:
 				local j=0;
-				text = string.gsub(text, "@", 
-					function() 
+				text = string.gsub(text, "@",
+					function()
 						j=j+1;
 						return minetest.get_meta({x=pos.x,y=pos.y+j,z=pos.z}):get_string("infotext")
 					end
@@ -1004,22 +1005,22 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 				--tmeta = minetest.get_meta(tpos);if not tmeta then return end
 				tmeta:set_string("text", text);
 			elseif string.byte(text) == 37 then -- target keypad's text starts with % ( ascii code 37) -> word extraction
-			
+
 				local ttext = minetest.get_meta({x=pos.x,y=pos.y+1,z=pos.z}):get_string("infotext")
 				local i = tonumber(string.sub(text,2,2)) or 1; --read the number following the %
-				--extract i-th word from text 
-				 local j = 0; 
-				 for word in string.gmatch(ttext, "%S+") do 
+				--extract i-th word from text
+				 local j = 0;
+				 for word in string.gmatch(ttext, "%S+") do
 					j=j+1; if j == i then text = word; break; end
 				 end
-				 
+
 				-- set target keypad's target's text
 				--tmeta = minetest.get_meta(tpos); if not tmeta then return end
 				tmeta:set_string("text", text);
-			else 
-			
+			else
+
 				if string.byte(text) == 64 then -- if text starts with @ clear target keypad text
-					tmeta:set_string("text",""); 
+					tmeta:set_string("text","");
 					return
 				end
 				-- just set text..
@@ -1028,7 +1029,7 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 			end
 			return
 		end
-		
+
 		if node.name == "basic_machines:detector" then -- change filter on detector
 			if string.byte(text) == 64 then -- if text starts with @ clear the filter
 				tmeta:set_string("node","");
@@ -1037,7 +1038,7 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 			end
 			return
 		end
-		
+
 		if node.name == "basic_machines:mover" then -- change filter on mover
 			if string.byte(text) == 64 then -- if text starts with @ clear the filter
 				tmeta:set_string("prefer","");
@@ -1048,7 +1049,7 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 			end
 			return
 		end
-		
+
 		if node.name == "basic_machines:distributor" then
 			local i = string.find(text," ");
 			if i then
@@ -1060,23 +1061,23 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 			end
 		return
 		end
-		
+
 		tmeta:set_string("infotext", text); -- else just set text
 	end
-	
-	
+
+
 	--activate target
 	local table = minetest.registered_nodes[node.name];
 	if not table then return end -- error
 	if not table.effector then return end -- error
 	local effector=table.effector;
-	
+
 	if mode == 3 then -- keypad in toggle mode
 		local state = meta:get_int("state") or 0;state = 1-state; meta:set_int("state",state);
 		if state == 0 then mode = 1 else mode = 2 end
 	end
 	-- pass the signal on to target
-	
+
 	if mode == 2 then -- on
 		if not effector.action_on then return end
 		effector.action_on(tpos,node,ttl-1); -- run
@@ -1084,31 +1085,31 @@ local function use_keypad(pos,ttl, again) -- position, time to live ( how many t
 		if not effector.action_off then return end
 		effector.action_off(tpos,node,ttl-1); -- run
 	end
-			
+
 end
 
 local function check_keypad(pos,name,ttl) -- called only when manually activated via punch
 	local meta = minetest.get_meta(pos);
 	local pass =  meta:get_string("pass");
-	if pass == "" then 
+	if pass == "" then
 		local iter = meta:get_int("iter");
 		local count = meta:get_int("count");
 		if count<iter-1 or iter<2 then meta:set_int("active_repeats",0) end -- so that keypad can work again, at least one operation must have occured though
 		meta:set_int("count",iter); use_keypad(pos,machines_TTL,0) -- time to live set when punched
-		return 
+		return
 	end
 	if name == "" then return end
-		
+
 	if meta:get_string("text") == "@" then -- keypad works as a keyboard
-		local form  = 
+		local form  =
 		"size[3,1]" ..  -- width, height
 		"field[0.25,0.25;3,1;pass;Enter text: ;".."".."] button_exit[0.,0.5;1,1;OK;OK]";
 		minetest.show_formspec(name, "basic_machines:check_keypad_"..minetest.pos_to_string(pos), form)
 		return
 	end
-	
+
 	pass = ""
-	local form  = 
+	local form  =
 		"size[3,1.25]" ..  -- width, height
 		"bgcolor[#FF8888BB; false]" ..
 		"field[0.25,0.25;3,1;pass;Enter Password: ;".."".."] button_exit[0.,0.75;1,1;OK;OK]";
@@ -1127,49 +1128,49 @@ minetest.register_node("basic_machines:keypad", {
 		meta:set_string("infotext", "Keypad. Right click to set it up or punch it. Set any password and text \"@\" to work as keyboard.")
 		meta:set_string("owner", placer:get_player_name()); meta:set_int("public",1);
 		meta:set_int("x0",0);meta:set_int("y0",0);meta:set_int("z0",0); -- target
-	
+
 		meta:set_string("pass", "");meta:set_int("mode",2); -- pasword, mode of operation
 		meta:set_int("iter",1);meta:set_int("count",0); -- how many repeats to do, current repeat count
 		local name = placer:get_player_name();punchset[name] =  {};punchset[name].state = 0
 	end,
-		
-	effector = { 
-		action_on = function (pos, node,ttl) 
+
+	effector = {
+		action_on = function (pos, node,ttl)
 		if type(ttl)~="number" then ttl = 1 end
 		if ttl<0 then return end -- machines_TTL prevents infinite recursion
 		use_keypad(pos,0,0) -- activate just 1 time
 	end
 	},
-	
+
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
 		local meta = minetest.get_meta(pos);
 		local privs = minetest.get_player_privs(player:get_player_name());
 		local cant_build = minetest.is_protected(pos,player:get_player_name());
-		--meta:get_string("owner")~=player:get_player_name() and 
-		if not privs.privs and cant_build then 
-			return 
+		--meta:get_string("owner")~=player:get_player_name() and
+		if not privs.privs and cant_build then
+			return
 		end -- only  ppl sharing protection can set up keypad
 		local x0,y0,z0,x1,y1,z1,pass,iter,mode;
 		x0=meta:get_int("x0");y0=meta:get_int("y0");z0=meta:get_int("z0");iter=meta:get_int("iter") or 1;
 		local text = meta:get_string("text") or "";
 		mode = meta:get_int("mode") or 1;
-		
+
 		machines.pos1[player:get_player_name()] = {x=pos.x+x0,y=pos.y+y0,z=pos.z+z0};machines.mark_pos1(player:get_player_name()) -- mark pos1
-		
+
 		pass = meta:get_string("pass");
-		local form  = 
+		local form  =
 		"size[4.75,3.75]" ..  -- width, height
 		"bgcolor[#888888BB; false]" ..
-		"field[2.5,0.25;2.25,1;pass;Password: ;"..pass.."]" .. 
+		"field[2.5,0.25;2.25,1;pass;Password: ;"..pass.."]" ..
 		"field[0.25,2.5;3.25,1;text;text;".. text .."]" ..
 		"field[0.25,0.25;1,1;mode;mode;"..mode.."]".. "field[1.25,0.25;1.1,1;iter;repeat;".. iter .."]"..
-		
+
 		"label[0.,0.75;".. minetest.colorize("lawngreen","MODE: 1=OFF/2=ON/3=TOGGLE").."]"..
 		"field[0.25,3.5;1,1;x0;target;"..x0.."] field[1.25,3.5;1,1;y0;;"..y0.."] field[2.25,3.5;1,1;z0;;"..z0.."]"..
 		"button[3.25,3.25;1,1;help;help] button_exit[3.25,2.25;1,1;OK;OK]"
 
 
-		
+
 		;
 		-- if meta:get_string("owner")==player:get_player_name() then
 			minetest.show_formspec(player:get_player_name(), "basic_machines:keypad_"..minetest.pos_to_string(pos), form)
@@ -1200,8 +1201,8 @@ minetest.register_node("basic_machines:detector", {
 		meta:set_string("mode","node");
 		meta:set_int("public",0);
 		meta:set_int("state",0);
-		
-		local inv = meta:get_inventory();inv:set_size("mode_select", 3*1) 
+
+		local inv = meta:get_inventory();inv:set_size("mode_select", 3*1)
 		inv:set_stack("mode_select", 1, ItemStack("default:coal_lump"))
 		local name = placer:get_player_name();punchset[name] =  {}; punchset[name].node = "";	punchset[name].state = 0
 	end,
@@ -1209,13 +1210,13 @@ minetest.register_node("basic_machines:detector", {
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
 		local meta = minetest.get_meta(pos);
 		local privs = minetest.get_player_privs(player:get_player_name());
-		
+
 		local cant_build = minetest.is_protected(pos,player:get_player_name());
 		--meta:get_string("owner")~=player:get_player_name() and
-		if not privs.privs  and cant_build then 
-			return 
-		end 
-		
+		if not privs.privs  and cant_build then
+			return
+		end
+
 		local x0,y0,z0,x1,y1,z1,x2,y2,z2,r,node,NOT,mode,op;
 		x0=meta:get_int("x0");y0=meta:get_int("y0");z0=meta:get_int("z0");
 		x1=meta:get_int("x1");y1=meta:get_int("y1");z1=meta:get_int("z1");
@@ -1225,7 +1226,7 @@ minetest.register_node("basic_machines:detector", {
 		mode = mode_list[mode] or 1;
 		local op_list = {[""]=1,["AND"]=2,["OR"]=3};
 		op = op_list[op] or 1;
-		
+
 
 		machines.pos1[player:get_player_name()] = {x=pos.x+x0,y=pos.y+y0,z=pos.z+z0};machines.mark_pos1(player:get_player_name()) -- mark pos1
 		machines.pos11[player:get_player_name()] = {x=pos.x+x1,y=pos.y+y1,z=pos.z+z1};machines.mark_pos11(player:get_player_name()) -- mark pos11
@@ -1236,20 +1237,20 @@ minetest.register_node("basic_machines:detector", {
 		local meta1=minetest.get_meta({x=pos.x+x0,y=pos.y+y0,z=pos.z+z0});
 		local list1 = meta1:get_inventory():get_lists(); local inv_list1 = ""; local j;
 		j=1; -- stupid dropdown requires item index but returns string on receive so we have to find index.. grrr, one other solution: invert the table: key <-> value
-		
-		for i in pairs( list1) do 
-			inv_list1 = inv_list1 .. i .. ","; 
+
+		for i in pairs( list1) do
+			inv_list1 = inv_list1 .. i .. ",";
 			if i == inv1m then inv1=j end; j=j+1;
 		end
-		
+
 		node=meta:get_string("node") or "";
 		NOT=meta:get_int("NOT");
 		local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z
-		local form  = 
+		local form  =
 		"size[4,6.25]" ..  -- width, height
-		"field[0.25,0.5;1,1;x0;source1;"..x0.."] field[1.25,0.5;1,1;y0;;"..y0.."] field[2.25,0.5;1,1;z0;;"..z0.."]".. 
+		"field[0.25,0.5;1,1;x0;source1;"..x0.."] field[1.25,0.5;1,1;y0;;"..y0.."] field[2.25,0.5;1,1;z0;;"..z0.."]"..
 		"dropdown[3,0.25;1,1;op; ,AND,OR;".. op .."]"..
-		"field[0.25,1.5;1,1;x1;source2;"..x1.."] field[1.25,1.5;1,1;y1;;"..y1.."] field[2.25,1.5;1,1;z1;;"..z1.."]".. 
+		"field[0.25,1.5;1,1;x1;source2;"..x1.."] field[1.25,1.5;1,1;y1;;"..y1.."] field[2.25,1.5;1,1;z1;;"..z1.."]"..
 		"field[0.25,2.5;1,1;x2;target;"..x2.."] field[1.25,2.5;1,1;y2;;"..y2.."] field[2.25,2.5;1,1;z2;;"..z2.."]"..
 		"field[0.25,3.5;2,1;node;Node/player/object: ;"..node.."]".."field[3.25,2.5;1,1;r;radius;"..r.."]"..
 		"dropdown[0,4.5;3,1;mode;node,player,object,inventory,infotext,light;".. mode .."]"..
@@ -1258,30 +1259,30 @@ minetest.register_node("basic_machines:detector", {
 		"label[0.,5.2;inventory selection]"..
 		"field[2.25,3.5;2,1;NOT;filter out -2/-1/0/1/2/3/4;"..NOT.."]"..
 		"button[3.,4.4;1,1;help;help] button_exit[3.,5.4;1,1;OK;OK] "
-		
+
 		--if meta:get_string("owner")==player:get_player_name() then
 			minetest.show_formspec(player:get_player_name(), "basic_machines:detector_"..minetest.pos_to_string(pos), form)
 		-- else
 			-- minetest.show_formspec(player:get_player_name(), "view_only_basic_machines_detector", form)
 		-- end
 	end,
-	
+
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		local meta = minetest.get_meta(pos);
 		local mode = "node";
-		if to_index == 2 then 
+		if to_index == 2 then
 			mode = "player";
 			meta:set_int("r",math.max(meta:get_int("r"),1))
 		end
-		if to_index == 3 then 
+		if to_index == 3 then
 			mode = "object";
 			meta:set_int("r",math.max(meta:get_int("r"),1))
 		end
@@ -1289,19 +1290,19 @@ minetest.register_node("basic_machines:detector", {
 		minetest.chat_send_player(player:get_player_name(), "DETECTOR: Mode of operation set  to: "..mode)
 		return count
 	end,
-	
+
 	effector = {
 		action_on = function (pos, node,ttl)
-			
+
 			if type(ttl)~="number" then ttl = 1 end
 			if ttl<0 then return end
-			
+
 			local meta = minetest.get_meta(pos);
-			
+
 			local t0 = meta:get_int("t");
-			local t1 = minetest.get_gametime(); 
+			local t1 = minetest.get_gametime();
 			local T = meta:get_int("T"); -- temperature
-			
+
 			if t0>t1-machines_minstep then -- activated before natural time
 				T=T+1;
 			else
@@ -1309,28 +1310,28 @@ minetest.register_node("basic_machines:detector", {
 			end
 			meta:set_int("T",T);
 			meta:set_int("t",t1); -- update last activation time
-			
+
 			if T > 2 then -- overheat
 					minetest.sound_play("default_cool_lava",{pos = pos, max_hear_distance = 16, gain = 0.25})
 					meta:set_string("infotext","overheat: temperature ".. T)
 					return
-			end			
+			end
 
-			
+
 			local x0,y0,z0,x1,y1,z1,x2,y2,z2,r,node,NOT,mode,op;
 			x0=meta:get_int("x0")+pos.x;y0=meta:get_int("y0")+pos.y;z0=meta:get_int("z0")+pos.z;
 			x2=meta:get_int("x2")+pos.x;y2=meta:get_int("y2")+pos.y;z2=meta:get_int("z2")+pos.z;
-			
+
 			r = meta:get_int("r") or 0; NOT = meta:get_int("NOT")
 			node=meta:get_string("node") or ""; mode=meta:get_string("mode") or ""; op = meta:get_string("op") or "";
-			
+
 			local trigger = false
 			local detected_obj = "";
 
 			if mode == "node" then
 				local tnode = minetest.get_node({x=x0,y=y0,z=z0}).name; -- read node at source position
 				detected_obj = tnode;
-				
+
 				if node~="" and string.find(tnode,"default:chest") then -- if source is chest, look inside chest for items
 					local cmeta = minetest.get_meta({x=x0,y=y0,z=z0});
 					local inv = cmeta:get_inventory();
@@ -1343,13 +1344,13 @@ minetest.register_node("basic_machines:detector", {
 						if node ~= "" and found_node then trigger = true end
 					end
 				end
-				
+
 				-- operation: AND, OR... look at other source position too
-				if op~= "" then 
+				if op~= "" then
 					local trigger1 = false;
 					x1=meta:get_int("x1")+pos.x;y1=meta:get_int("y1")+pos.y;z1=meta:get_int("z1")+pos.z;
 					tnode = minetest.get_node({x=x1,y=y1,z=z1}).name; -- read node at source position
-				
+
 					if node~="" and string.find(tnode,"default:chest") then -- it source is chest, look inside chest for items
 						local cmeta = minetest.get_meta({x=x1,y=y1,z=z1});
 						local inv = cmeta:get_inventory();
@@ -1362,7 +1363,7 @@ minetest.register_node("basic_machines:detector", {
 							if node ~= "" and found_node then trigger1 = true end
 						end
 					end
-					if op == "AND" then 
+					if op == "AND" then
 						trigger = trigger and trigger1;
 					elseif op == "OR" then
 						trigger = trigger or trigger1;
@@ -1372,12 +1373,12 @@ minetest.register_node("basic_machines:detector", {
 			elseif mode=="inventory" then
 				local cmeta = minetest.get_meta({x=x0,y=y0,z=z0});
 				local inv = cmeta:get_inventory();
-				
+
 				local inv1m =meta:get_string("inv1");
-				
+
 				if node == "" then -- if there is item report name and trigger
-					if inv:is_empty(inv1m) then 
-						trigger = false  
+					if inv:is_empty(inv1m) then
+						trigger = false
 					else -- nonempty
 						trigger = true
 						local size = inv:get_size(inv1m);
@@ -1385,12 +1386,12 @@ minetest.register_node("basic_machines:detector", {
 							local stack = inv:get_stack(inv1m, i);
 							if not stack:is_empty() then detected_obj = stack:to_string() break end
 						end
-					end 
+					end
 				else -- node name was set
-					local stack = ItemStack(node); 
+					local stack = ItemStack(node);
 					if inv:contains_item(inv1m, stack) then trigger = true end
 				end
-				
+
 			elseif mode == "infotext" then
 				local cmeta = minetest.get_meta({x=x0,y=y0,z=z0});
 				detected_obj = cmeta:get_string("infotext");
@@ -1403,38 +1404,38 @@ minetest.register_node("basic_machines:detector", {
 				local player_near=false;
 				for _,obj in pairs(objects) do
 					if mode == "player" then
-						if obj:is_player() then 
+						if obj:is_player() then
 
 							player_near = true
 							detected_obj = obj:get_player_name();
-							if (node=="" or detected_obj==node) then 
-								trigger = true break 
+							if (node=="" or detected_obj==node) then
+								trigger = true break
 							end
-							
+
 						end;
 					elseif mode == "object" and not obj:is_player() then
 						if obj:get_luaentity() then
 							detected_obj = obj:get_luaentity().itemstring or "";
-							if detected_obj == "" then 
-								detected_obj = obj:get_luaentity().name or "" 
+							if detected_obj == "" then
+								detected_obj = obj:get_luaentity().name or ""
 							end
-							
+
 							if detected_obj==node then trigger=true break end
 						end
 						if node=="" then trigger = true break end
 					end
 				end
-				
-				if node~="" and NOT==-1 and not(trigger) and not(player_near) and mode == "player" then 
-					trigger = true 
+
+				if node~="" and NOT==-1 and not(trigger) and not(player_near) and mode == "player" then
+					trigger = true
 				end-- name specified, but noone around and negation -> 0
-				
+
 			end
-			
+
 			-- negation and output filtering
 			local state = meta:get_int("state");
-			
-			
+
+
 			if NOT ==  1 then -- just go on normally
 				-- -2: only false, -1: NOT, 0: no signal, 1: normal signal: 2: only true
 				elseif NOT == -1 then trigger = not trigger -- NEGATION
@@ -1443,18 +1444,18 @@ minetest.register_node("basic_machines:detector", {
 				elseif NOT == 2 and not trigger then return  -- ONLY TRUE
 				elseif NOT == 3 and ((trigger and state == 1) or (not trigger and state == 0)) then return -- no change of state
 			end
-			
+
 			local nstate;
 			if trigger then nstate = 1 else nstate=0 end -- next detector output state
 			if nstate~=state then meta:set_int("state",nstate) end -- update state if changed
-			
-			
+
+
 			local node = minetest.get_node({x=x2,y=y2,z=z2});if not node.name then return end -- error
 			local table = minetest.registered_nodes[node.name];
 			if not table then return end -- error
 			if not table.effector then return end -- error
 			local effector=table.effector;
-				
+
 			if trigger then -- activate target node if succesful
 				meta:set_string("infotext", "detector: on");
 				if not effector.action_on then return end
@@ -1466,7 +1467,7 @@ minetest.register_node("basic_machines:detector", {
 					end
 				end
 				effector.action_on({x=x2,y=y2,z=z2},node,ttl-1); -- run
-			else 
+			else
 				meta:set_string("infotext", "detector: off");
 				if not effector.action_off then return end
 				effector.action_off({x=x2,y=y2,z=z2},node,ttl-1); -- run
@@ -1492,31 +1493,31 @@ minetest.register_chatcommand("clockgen", { -- test: toggle machine running with
 
 
 -- CLOCK GENERATOR : periodically activates machine on top of it
-minetest.register_abm({ 
+minetest.register_abm({
 	nodenames = {"basic_machines:clockgen"},
 	neighbors = {},
 	interval = machines_timer,
 	chance = 1,
-	
+
 	action = function(pos, node, active_object_count, active_object_count_wider)
 		if basic_machines.clockgen == 0 then return end
-		local meta = minetest.get_meta(pos); 
+		local meta = minetest.get_meta(pos);
 		local machines = meta:get_int("machines");
 		if machines~=1 then -- no machines privilege
 			if not minetest.get_player_by_name(meta:get_string("owner")) then -- owner not online
-				return 
+				return
 			end
 		end
-		
+
 		pos.y=pos.y+1;
-		node = minetest.get_node(pos);if not node.name or node.name == "air" then return end 
+		node = minetest.get_node(pos);if not node.name or node.name == "air" then return end
 		local table = minetest.registered_nodes[node.name];
 		if table and table.effector then -- check if all elements exist, safe cause it checks from left to right
-			else return 
+			else return
 		end
 		local effector=table.effector;
 		if effector.action_on then
-			effector.action_on(pos,node,machines_TTL); 
+			effector.action_on(pos,node,machines_TTL);
 		end
 	end
 	});
@@ -1533,17 +1534,17 @@ minetest.register_node("basic_machines:clockgen", {
 			minetest.chat_send_player(placer:get_player_name(),"#clock generator: interference from nearby clock generator detected.")
 			return
 		end
-		
+
 		local meta =  minetest.get_meta(pos);
 		local owner = placer:get_player_name() or "";
 		local privs = minetest.get_player_privs(owner);
 		if privs.machines then meta:set_int("machines",1) end
-		
+
 		meta:set_string("owner",owner);
 		meta:set_string("infotext","clock generator (owned by " .. owner .. "): place machine to be activated on top of generator");
 	end
-})	
-	
+})
+
 
 -- DISTRIBUTOR --
 local get_distributor_form = function(pos,player)
@@ -1551,11 +1552,11 @@ local get_distributor_form = function(pos,player)
 	local meta = minetest.get_meta(pos);
 	local privs = minetest.get_player_privs(player:get_player_name());
 	local cant_build = minetest.is_protected(pos,player:get_player_name());
-	--meta:get_string("owner")~=player:get_player_name() and 
-	if not privs.privs and cant_build then 
-		return 
-	end 
-	
+	--meta:get_string("owner")~=player:get_player_name() and
+	if not privs.privs and cant_build then
+		return
+	end
+
 	local p = {}; local active = {};
 	local n = meta:get_int("n");
 	local delay = meta:get_float("delay");
@@ -1563,36 +1564,36 @@ local get_distributor_form = function(pos,player)
 		p[i]={x=meta:get_int("x"..i),y=meta:get_int("y"..i),z=meta:get_int("z"..i)};
 		active[i]=meta:get_int("active"..i);
 	end
-	
+
 	local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z
 	local view = meta:get_int("view")
-	
+
 	if view == 0 then
-		local form  = 
+		local form  =
 		"size[7,"..(0.75+(n)*0.75).."]" ..  -- width, height
 		"label[0,-0.25;" .. minetest.colorize("lawngreen","target: x y z, MODE") .. "]";
 		for i =1,n do
 			form = form.."field[0.25,"..(0.5+(i-1)*0.75)..";1,1;x"..i..";;"..p[i].x.."] field[1.25,"..(0.5+(i-1)*0.75)..";1,1;y"..i..";;"..p[i].y.."] field[2.25,"..(0.5+(i-1)*0.75)..";1,1;z"..i..";;"..p[i].z.."] field [ 3.25,"..(0.5+(i-1)*0.75)..";1,1;active"..i..";;" .. active[i] .. "]"
 			form = form .. "button[4.,"..(0.25+(i-1)*0.75)..";1.5,1;SHOW"..i..";SHOW "..i.."]".."button_exit[5.25,"..(0.25+(i-1)*0.75)..";1,1;SET"..i..";SET]".."button[6.25,"..(0.25+(i-1)*0.75)..";1,1;X"..i..";X]"
 		end
-		
+
 		form=form.."button[4.0,"..(0.25+(n)*0.75)..";1,1;ADD;ADD]"..
 		"button[5.25,"..(0.25+(n)*0.75)..";1,1;view;view]"..
 		"button_exit[3.,"..(0.25+(n)*0.75)..";1,1;OK;OK]".."field[0.25,"..(0.5+(n)*0.75)..";1,1;delay;delay;"..delay .. "]";
 		form = form.."button[6.25,"..(0.25+(n)*0.75)..";1,1;help;help]";
 		return form
-	else 
-		local form  = 
+	else
+		local form  =
 		"size[7,"..(0.75+(n)*0.75).."]" ..  -- width, height
 		"label[0,-0.25;" .. minetest.colorize("lawngreen","target name, MODE -2=only OFF, -1=NOT input/0/1=input, 2 = only ON") .. "]";
 		for i =1,n do
 			local tname = minetest.get_node({x=p[i].x+pos.x,y=p[i].y+pos.y,z=p[i].z+pos.z}).name;
 			local ti = string.find(tname,":") or 0; tname = p[i].x .. " " .. p[i].y .. " " .. p[i].z .. " " .. string.sub(tname,ti+1);
-			
+
 			form = form.."field[0.25,"..(0.5+(i-1)*0.75)..";3,1;text;;" .. tname .. "] field [ 3.25,"..(0.5+(i-1)*0.75)..";1,1;active"..i..";;" .. active[i] .. "]"
 			form = form .. "button[4.,"..(0.25+(i-1)*0.75)..";1.5,1;SHOW"..i..";SHOW "..i.."]".."button_exit[5.25,"..(0.25+(i-1)*0.75)..";1,1;SET"..i..";SET]".."button[6.25,"..(0.25+(i-1)*0.75)..";1,1;X"..i..";X]"
 		end
-		
+
 		form=form.."button[4.0,"..(0.25+(n)*0.75)..";1,1;ADD;ADD]"..
 		"button_exit[2.0,"..(0.25+(n)*0.75)..";1,1;scan;scan]"..
 		"button[5.25,"..(0.25+(n)*0.75)..";1,1;view;view]"..
@@ -1618,43 +1619,43 @@ minetest.register_node("basic_machines:distributor", {
 		end
 		meta:set_int("n",2); -- how many targets initially
 		meta:set_float("delay",0); -- delay when transmitting signal
-		
-		
+
+
 		meta:set_int("public",0); -- can other ppl set it up?
 		local name = placer:get_player_name();punchset[name] =  {}; punchset[name].node = "";	punchset[name].state = 0
 	end,
-		
+
 	effector = {
-		action_on = function (pos, node,ttl) 
+		action_on = function (pos, node,ttl)
 
 			if type(ttl)~="number" then ttl = 1 end
 			if not(ttl>0) then return end
 			local meta = minetest.get_meta(pos);
 
 			local t0 = meta:get_int("t");
-			local t1 = minetest.get_gametime(); 
+			local t1 = minetest.get_gametime();
 			local T = meta:get_int("T"); -- temperature
-			
+
 			if t0>t1-machines_minstep then -- activated before natural time
 				T=T+1;
 			else
-				if T>0 then 
-					T=T-1 
+				if T>0 then
+					T=T-1
 					if t1-t0>5 then T = 0 end -- reset temperature if more than 5s elapsed since last punch
 				end
-				
+
 			end
 			meta:set_int("T",T);
 			meta:set_int("t",t1); -- update last activation time
-			
+
 			if T > 2 then -- overheat
 					minetest.sound_play("default_cool_lava",{pos = pos, max_hear_distance = 16, gain = 0.25})
 					meta:set_string("infotext","overheat: temperature ".. T)
 					return
 			end
-			
+
 			local delay = minetest.get_meta(pos):get_float("delay");
-			
+
 			local activate = function()
 				local posf = {}; local active = {};
 				local n = meta:get_int("n");local delay = meta:get_float("delay");
@@ -1662,32 +1663,32 @@ minetest.register_node("basic_machines:distributor", {
 					posf[i]={x=meta:get_int("x"..i)+pos.x,y=meta:get_int("y"..i)+pos.y,z=meta:get_int("z"..i)+pos.z};
 					active[i]=meta:get_int("active"..i);
 				end
-				
+
 				local table,node;
-			
+
 				for i=1,n do
-					if active[i]~=0 then 
+					if active[i]~=0 then
 						node = minetest.get_node(posf[i]);if not node.name then return end -- error
 						table = minetest.registered_nodes[node.name];
-						
+
 						if table and table.effector then -- check if all elements exist, safe cause it checks from left to right
-														
+
 							local effector=table.effector;
 							local active_i = active[i];
-							
+
 							if (active_i == 1 or active_i == 2) and effector.action_on then -- normal OR only forward input ON
-								effector.action_on(posf[i],node,ttl-1); 
-							elseif active_i == -1 and effector.action_off then 
+								effector.action_on(posf[i],node,ttl-1);
+							elseif active_i == -1 and effector.action_off then
 								effector.action_off(posf[i],node,ttl-1)
 							end
 						end
-						
+
 					end
 				end
 			end
-			
-			if delay>0 then 
-				minetest.after(delay, activate) 
+
+			if delay>0 then
+				minetest.after(delay, activate)
 			elseif delay == 0 then
 				activate()
 			else -- delay <0 - do random activation: delay = -500 means 500/1000 chance to activate
@@ -1695,20 +1696,20 @@ minetest.register_node("basic_machines:distributor", {
 					activate()
 				end
 			end
-			
+
 	end,
-	
-	action_off = function (pos, node,ttl) 
-			
+
+	action_off = function (pos, node,ttl)
+
 			if type(ttl)~="number" then ttl = 1 end
 			if not(ttl>0) then return end
 			local meta = minetest.get_meta(pos);
 
-			
+
 			local t0 = meta:get_int("t");
-			local t1 = minetest.get_gametime(); 
+			local t1 = minetest.get_gametime();
 			local T = meta:get_int("T"); -- temperature
-			
+
 			if t0>t1-machines_minstep then -- activated before natural time
 				T=T+1;
 			else
@@ -1716,14 +1717,14 @@ minetest.register_node("basic_machines:distributor", {
 			end
 			meta:set_int("T",T);
 			meta:set_int("t",t1); -- update last activation time
-			
+
 			if T > 2 then -- overheat
 					minetest.sound_play("default_cool_lava",{pos = pos, max_hear_distance = 16, gain = 0.25})
 					meta:set_string("infotext","overheat: temperature ".. T)
 					return
 			end
 			local delay = minetest.get_meta(pos):get_float("delay");
-			
+
 			local activate = function()
 				local posf = {}; local active = {};
 				local n = meta:get_int("n");
@@ -1731,28 +1732,28 @@ minetest.register_node("basic_machines:distributor", {
 					posf[i]={x=meta:get_int("x"..i)+pos.x,y=meta:get_int("y"..i)+pos.y,z=meta:get_int("z"..i)+pos.z};
 					active[i]=meta:get_int("active"..i);
 				end
-				
+
 				local node, table
-				
-				
+
+
 				for i=1,n do
 					if active[i]~=0 then
 						node = minetest.get_node(posf[i]);if not node.name then return end -- error
 						table = minetest.registered_nodes[node.name];
-						if table and table.effector then 
+						if table and table.effector then
 							local effector=table.effector;
 							if (active[i] == 1 or active[i]==-2) and effector.action_off then  -- normal OR only forward input OFF
-								effector.action_off(posf[i],node,ttl-1); 
-							elseif (active[i] == -1) and effector.action_on then 
-								effector.action_on(posf[i],node,ttl-1); 
+								effector.action_off(posf[i],node,ttl-1);
+							elseif (active[i] == -1) and effector.action_on then
+								effector.action_on(posf[i],node,ttl-1);
 							end
 						end
 					end
 				end
 			end
-			
+
 			if delay>0 then minetest.after(delay, activate) else activate() end
-			
+
 	end
 	},
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
@@ -1770,14 +1771,14 @@ minetest.register_node("basic_machines:light_off", {
 	tiles = {"light_off.png"},
 	groups = {cracky=3},
 	effector = {
-		action_on = function (pos, node,ttl) 
-			minetest.swap_node(pos,{name = "basic_machines:light_on"});		
+		action_on = function (pos, node,ttl)
+			minetest.swap_node(pos,{name = "basic_machines:light_on"});
 			local meta = minetest.get_meta(pos);
 			local deactivate = meta:get_int("deactivate");
-			
-			if deactivate > 0 then 
+
+			if deactivate > 0 then
 					--meta:set_int("active",0);
-					minetest.after(deactivate, 
+					minetest.after(deactivate,
 						function()
 							--if meta:get_int("active") ~= 1 then -- was not activated again, so turn it off
 								minetest.swap_node(pos,{name = "basic_machines:light_off"}); -- turn off again
@@ -1798,12 +1799,12 @@ minetest.register_node("basic_machines:light_on", {
 	light_source = LIGHT_MAX,
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos);
-		local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z 
+		local list_name = "nodemeta:"..pos.x..','..pos.y..','..pos.z
 		local deactivate = meta:get_int("deactivate");
 		local form  = "size[2,2] field[0.25,0.5;2,1;deactivate;deactivate after ;"..deactivate.."]".."button_exit[0.,1;1,1;OK;OK]";
-		
+
 		meta:set_string("formspec", form);
-	end,	
+	end,
 	on_receive_fields = function(pos, formname, fields, player)
         if minetest.is_protected(pos, player:get_player_name()) then return end
 		if fields.deactivate then
@@ -1814,20 +1815,20 @@ minetest.register_node("basic_machines:light_on", {
 			local form  = "size[2,2] field[0.25,0.5;2,1;deactivate;deactivate after ;"..deactivate.."]".."button_exit[0.,1;1,1;OK;OK]";
 			meta:set_string("formspec", form);
 		end
-        
+
     end,
-	
+
 	effector = {
-		action_off = function (pos, node,ttl) 
-			minetest.swap_node(pos,{name = "basic_machines:light_off"});		
+		action_off = function (pos, node,ttl)
+			minetest.swap_node(pos,{name = "basic_machines:light_off"});
 		end,
-		action_on = function (pos, node,ttl) 
+		action_on = function (pos, node,ttl)
 			local meta = minetest.get_meta(pos);
 			local count = tonumber(meta:get_string("infotext")) or 0;
 			meta:set_string("infotext",count+1); -- increase activate count
 		end
 	},
-	
+
 })
 
 
@@ -1836,44 +1837,44 @@ punchset.known_nodes = {["basic_machines:mover"]=true,["basic_machines:keypad"]=
 
 -- SETUP BY PUNCHING
 minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
-	
+
 	-- STRANGE PROBLEM: if player doesnt move it takes another punch at same block for this function to run again, and it works normally if player moved at least one block from his previous position
 	-- it only happens with keypad - maybe caused by formspec displayed..
-	
+
 	local name = puncher:get_player_name(); if name==nil then return end
 	if punchset[name]== nil then  -- set up punchstate
-		punchset[name] = {} 
+		punchset[name] = {}
 		punchset[name].node = ""
 		punchset[name].pos1 = {x=0,y=0,z=0};punchset[name].pos2 = {x=0,y=0,z=0};punchset[name].pos = {x=0,y=0,z=0};
 		punchset[name].state = 0; -- 0 ready for punch, 1 ready for start position, 2 ready for end position
 		return
 	end
 
-	
+
 	-- check for known node names in case of first punch
 	if punchset[name].state == 0 and not punchset.known_nodes[node.name] then return end
 	-- from now on only punches with mover/keypad/... or setup punches
-	
+
 	if punchset.known_nodes[node.name] then  -- check if player is suppose to be able to punch interact
 			if node.name~="basic_machines:keypad" then -- keypad is supposed to be punch interactive!
 				if minetest.is_protected(pos, name) then return end
 			end
 	end
-	
+
 	if node.name == "basic_machines:mover" then -- mover init code
-		if punchset[name].state == 0 then 
+		if punchset[name].state == 0 then
 			-- if not puncher:get_player_control().sneak then
 				-- return
 			-- end
 			minetest.chat_send_player(name, "MOVER: Now punch source1, source2, end position to set up mover.")
 			punchset[name].node = node.name;punchset[name].pos = {x=pos.x,y=pos.y,z=pos.z};
-			punchset[name].state = 1 
+			punchset[name].state = 1
 			return
 		end
 	end
-	
+
 	 if punchset[name].node == "basic_machines:mover" then -- mover code, not first punch
-		
+
 		if minetest.is_protected(pos,name) then
 			minetest.chat_send_player(name, "MOVER: Punched position is protected. aborting.")
 			punchset[name].node = "";
@@ -1882,48 +1883,48 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 
 		local meta = minetest.get_meta(punchset[name].pos);	if not meta then return end;
 		local range = meta:get_float("upgrade") or 1; range = range*max_range;
-		
-		if punchset[name].state == 1 then 
+
+		if punchset[name].state == 1 then
 			local privs = minetest.get_player_privs(puncher:get_player_name());
 			if not privs.privs and (math.abs(punchset[name].pos.x - pos.x)>range or math.abs(punchset[name].pos.y - pos.y)>range or math.abs(punchset[name].pos.z - pos.z)>range) then
 					minetest.chat_send_player(name, "MOVER: Punch closer to mover. reseting.")
 					punchset[name].state = 0; return
 			end
-			
-			if punchset[name].pos.x==pos.x and punchset[name].pos.y==pos.y and punchset[name].pos.z==pos.z then 
+
+			if punchset[name].pos.x==pos.x and punchset[name].pos.y==pos.y and punchset[name].pos.z==pos.z then
 				minetest.chat_send_player(name, "MOVER: Punch something else. aborting.")
 				punchset[name].state = 0;
-				return 
+				return
 			end
-			
+
 			punchset[name].pos1 = {x=pos.x,y=pos.y,z=pos.z};punchset[name].state = 2;
 			machines.pos1[name] = punchset[name].pos1;machines.mark_pos1(name) -- mark position
 			minetest.chat_send_player(name, "MOVER: Source1 position for mover set. Punch again to set source2 position.")
 			return
 		end
-		
-		
-		if punchset[name].state == 2 then 
+
+
+		if punchset[name].state == 2 then
 			local privs = minetest.get_player_privs(puncher:get_player_name());
 			if not privs.privs and (math.abs(punchset[name].pos.x - pos.x)>range or math.abs(punchset[name].pos.y - pos.y)>range or math.abs(punchset[name].pos.z - pos.z)>range) then
 					minetest.chat_send_player(name, "MOVER: Punch closer to mover. reseting.")
 					punchset[name].state = 0; return
 			end
-			
-			if punchset[name].pos.x==pos.x and punchset[name].pos.y==pos.y and punchset[name].pos.z==pos.z then 
+
+			if punchset[name].pos.x==pos.x and punchset[name].pos.y==pos.y and punchset[name].pos.z==pos.z then
 				minetest.chat_send_player(name, "MOVER: Punch something else. aborting.")
 				punchset[name].state = 0;
-				return 
+				return
 			end
-			
+
 			punchset[name].pos11 = {x=pos.x,y=pos.y,z=pos.z};punchset[name].state = 3;
 			machines.pos11[name] = {x=pos.x,y=pos.y,z=pos.z};
 			machines.mark_pos11(name) -- mark pos11
 			minetest.chat_send_player(name, "MOVER: Source2 position for mover set. Punch again to set target position.")
 			return
 		end
-		
-		if punchset[name].state == 3 then 
+
+		if punchset[name].state == 3 then
 			if punchset[name].node~="basic_machines:mover" then punchset[name].state = 0 return end
 			local privs = minetest.get_player_privs(puncher:get_player_name());
 			local elevator_mode = false;
@@ -1941,7 +1942,7 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 						if inv:get_stack("upgrade", 1):get_name() == "default:diamondblock" then
 							upgrade = (inv:get_stack("upgrade", 1):get_count()) or 0;
 						end
-						
+
 						local requirement = math.floor(ecost/100)+1;
 						if upgrade<requirement then
 							minetest.chat_send_player(name, "MOVER: Error while trying to make elevator. Need at least "..requirement .. " diamond block(s) in upgrade (1 for every 100 distance). ");
@@ -1953,34 +1954,34 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 							minetest.chat_send_player(name, "MOVER: elevator setup completed, upgrade level " .. upgrade);
 							meta:set_string("infotext", "ELEVATOR, activate to use.")
 						end
-						
+
 					end
-				
+
 				end
-				
+
 			end
-			
+
 			if not privs.privs and not elevator_mode and (math.abs(punchset[name].pos.x - pos.x)>range or math.abs(punchset[name].pos.y - pos.y)>range or math.abs(punchset[name].pos.z - pos.z)>range) then
 				minetest.chat_send_player(name, "MOVER: Punch closer to mover. aborting.")
 				punchset[name].state = 0; return
 			end
-			
+
 			punchset[name].pos2 = {x=pos.x,y=pos.y,z=pos.z}; punchset[name].state = 0;
 			machines.pos2[name] = punchset[name].pos2;machines.mark_pos2(name) -- mark pos2
-			
+
 			minetest.chat_send_player(name, "MOVER: End position for mover set.")
-			
+
 			local x0 = punchset[name].pos1.x-punchset[name].pos.x;
 			local y0 = punchset[name].pos1.y-punchset[name].pos.y;
 			local z0 = punchset[name].pos1.z-punchset[name].pos.z;
 			local meta = minetest.get_meta(punchset[name].pos);
-	
-			
+
+
 			local x1 = punchset[name].pos11.x-punchset[name].pos.x;
 			local y1 = punchset[name].pos11.y-punchset[name].pos.y;
 			local z1 = punchset[name].pos11.z-punchset[name].pos.z;
-			
-			
+
+
 			local x2 = punchset[name].pos2.x-punchset[name].pos.x;
 			local y2 = punchset[name].pos2.y-punchset[name].pos.y;
 			local z2 = punchset[name].pos2.z-punchset[name].pos.z;
@@ -1988,19 +1989,19 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 			if x0>x1 then x0,x1 = x1,x0 end -- this ensures that x0<=x1
 			if y0>y1 then y0,y1 = y1,y0 end
 			if z0>z1 then z0,z1 = z1,z0 end
-			
+
 			meta:set_int("x1",x1);meta:set_int("y1",y1);meta:set_int("z1",z1);
 			meta:set_int("x0",x0);meta:set_int("y0",y0);meta:set_int("z0",z0);
 			meta:set_int("x2",x2);meta:set_int("y2",y2);meta:set_int("z2",z2);
-			
+
 			meta:set_int("pc",0); meta:set_int("dim",(x1-x0+1)*(y1-y0+1)*(z1-z0+1))
 			return
 		end
 	end
-	
+
 	-- KEYPAD
 	if node.name == "basic_machines:keypad" then -- keypad init/usage code
-		
+
 		local meta = minetest.get_meta(pos);
 		if not (meta:get_int("x0")==0 and meta:get_int("y0")==0 and meta:get_int("z0")==0) then -- already configured
 			check_keypad(pos,name)-- not setup, just standard operation
@@ -2009,15 +2010,15 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 		else
 			if minetest.is_protected(pos, name) then return minetest.chat_send_player(name, "KEYPAD: You must be able to build to set up keypad.") end
 			--if meta:get_string("owner")~= name then minetest.chat_send_player(name, "KEYPAD: Only owner can set up keypad.") return end
-			if punchset[name].state == 0 then 
+			if punchset[name].state == 0 then
 				minetest.chat_send_player(name, "KEYPAD: Now punch the target block.")
 				punchset[name].node = node.name;punchset[name].pos = {x=pos.x,y=pos.y,z=pos.z};
-				punchset[name].state = 1 
+				punchset[name].state = 1
 				return
 			end
 		end
 	end
-	
+
 	if punchset[name].node=="basic_machines:keypad" then -- keypad setup code
 
 		if minetest.is_protected(pos,name) then
@@ -2026,7 +2027,7 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 			punchset[name].state = 0; return
 		end
 
-		if punchset[name].state == 1 then 
+		if punchset[name].state == 1 then
 			local meta = minetest.get_meta(punchset[name].pos);
 			local x = pos.x-punchset[name].pos.x;
 			local y = pos.y-punchset[name].pos.y;
@@ -2035,12 +2036,12 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 					minetest.chat_send_player(name, "KEYPAD: Punch closer to keypad. reseting.")
 					punchset[name].state = 0; return
 			end
-			
+
 			machines.pos1[name] = pos;
 			machines.mark_pos1(name) -- mark pos1
-			
-			meta:set_int("x0",x);meta:set_int("y0",y);meta:set_int("z0",z);	
-			punchset[name].state = 0 
+
+			meta:set_int("x0",x);meta:set_int("y0",y);meta:set_int("z0",z);
+			punchset[name].state = 0
 			minetest.chat_send_player(name, "KEYPAD: Keypad target set with coordinates " .. x .. " " .. y .. " " .. z)
 			meta:set_string("infotext", "Punch keypad to use it.");
 			return
@@ -2050,27 +2051,27 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 	-- DETECTOR "basic_machines:detector"
 	if node.name == "basic_machines:detector" then -- detector init code
 		local meta = minetest.get_meta(pos);
-			
+
 			--meta:get_string("owner")~= name
 			if minetest.is_protected(pos,name) then minetest.chat_send_player(name, "DETECTOR: You must be able to build to set up detector.") return end
-			if punchset[name].state == 0 then 
+			if punchset[name].state == 0 then
 				minetest.chat_send_player(name, "DETECTOR: Now punch the source block.")
 				punchset[name].node = node.name;
 				punchset[name].pos = {x=pos.x,y=pos.y,z=pos.z};
-				punchset[name].state = 1 
+				punchset[name].state = 1
 				return
 			end
 	end
-	
+
 	if punchset[name].node == "basic_machines:detector" then
-			
+
 			if minetest.is_protected(pos,name) then
 				minetest.chat_send_player(name, "DETECTOR: Punched position is protected. aborting.")
 				punchset[name].node = "";
 				punchset[name].state = 0; return
 			end
-			
-			if punchset[name].state == 1 then 
+
+			if punchset[name].state == 1 then
 				if math.abs(punchset[name].pos.x - pos.x)>max_range or math.abs(punchset[name].pos.y - pos.y)>max_range or math.abs(punchset[name].pos.z - pos.z)>max_range then
 					minetest.chat_send_player(name, "DETECTOR: Punch closer to detector. aborting.")
 					punchset[name].state = 0; return
@@ -2078,23 +2079,23 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 				minetest.chat_send_player(name, "DETECTOR: Now punch the target machine.")
 				punchset[name].pos1 = {x=pos.x,y=pos.y,z=pos.z};
 				machines.pos1[name] = pos;machines.mark_pos1(name) -- mark pos1
-				punchset[name].state = 2 
+				punchset[name].state = 2
 				return
 			end
-			
-			
-			if punchset[name].state == 2 then 
+
+
+			if punchset[name].state == 2 then
 				if math.abs(punchset[name].pos.x - pos.x)>max_range or math.abs(punchset[name].pos.y - pos.y)>max_range or math.abs(punchset[name].pos.z - pos.z)>max_range then
 					minetest.chat_send_player(name, "DETECTOR: Punch closer to detector. aborting.")
 					punchset[name].state = 0; return
 				end
-				
+
 				if punchset[name].pos.x == pos.x and punchset[name].pos.y == pos.y and punchset[name].pos.z == pos.z then
 					minetest.chat_send_player(name, "DETECTOR: Punch something else. aborting.")
 					punchset[name].state = 0; return
 				end
-				
-				
+
+
 				minetest.chat_send_player(name, "DETECTOR: Setup complete.")
 				machines.pos2[name] = pos;machines.mark_pos2(name) -- mark pos2
 				local x = punchset[name].pos1.x-punchset[name].pos.x;
@@ -2104,21 +2105,21 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 				meta:set_int("x0",x);meta:set_int("y0",y);meta:set_int("z0",z);
 				x=pos.x-punchset[name].pos.x;y=pos.y-punchset[name].pos.y;z=pos.z-punchset[name].pos.z;
 				meta:set_int("x2",x);meta:set_int("y2",y);meta:set_int("z2",z);
-				punchset[name].state = 0 
+				punchset[name].state = 0
 				return
 			end
 	end
-	
-	
+
+
 	if punchset[name].node == "basic_machines:distributor" then
-			
+
 			if minetest.is_protected(pos,name) then
 				minetest.chat_send_player(name, "DISTRIBUTOR: Punched position is protected. aborting.")
 				punchset[name].node = "";
 				punchset[name].state = 0; return
 			end
-			
-			if punchset[name].state > 0 then 
+
+			if punchset[name].state > 0 then
 				if math.abs(punchset[name].pos.x - pos.x)>2*max_range or math.abs(punchset[name].pos.y - pos.y)>2*max_range or math.abs(punchset[name].pos.z - pos.z)>2*max_range then
 					minetest.chat_send_player(name, "DISTRIBUTOR: Punch closer to distributor. aborting.")
 					punchset[name].state = 0; return
@@ -2129,23 +2130,23 @@ minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
 				local y = pos.y-punchset[name].pos.y;
 				local z = pos.z-punchset[name].pos.z;
 				local j = punchset[name].state;
-				
+
 				meta:set_int("x"..j,x);meta:set_int("y"..j,y);meta:set_int("z"..j,z);
 				if x==0 and y==0 and z==0 then meta:set_int("active"..j,0) end
 				machines.pos1[name] = pos;machines.mark_pos1(name) -- mark pos1
-				punchset[name].state = 0; 
+				punchset[name].state = 0;
 				return
 			end
-		
+
 	end
-	
-	
-	
+
+
+
 end)
 
 -- FORM PROCESSING for all machines
 minetest.register_on_player_receive_fields(function(player,formname,fields)
-	
+
 	-- MOVER
 	local fname = "basic_machines:mover_"
 	if string.sub(formname,0,string.len(fname)) == fname then
@@ -2155,10 +2156,10 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 		local privs = minetest.get_player_privs(name);
 		if not fields then return end
 		local can_edit =  (not minetest.is_protected(pos,name)) or privs.privs
-		
+
 		if not can_edit and not fields.tabs then return end
-		
-	
+
+
 		if fields.help == "help" then
 			local text = "version " .. basic_machines.version .. "\nSETUP: For interactive setup "..
 			"punch the mover and then punch source1, source2, target node (follow instructions). Put charged battery within distance 1 from mover. For advanced setup right click mover. Positions are defined by x y z coordinates (see top of mover for orientation). Mover itself is at coordinates 0 0 0. "..
@@ -2173,42 +2174,42 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 			minetest.show_formspec(name, "basic_machines:help_mover", form)
 			return
 		end
-		
+
 		if fields.tabs then
 			meta:set_int("seltab", tonumber(fields.tabs) or 1)
 			local form = get_mover_form(pos,player)
 			minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
 			return
 		end
-		
+
 		if fields.OK == "OK" then
-			
+
 			local seltab = meta:get_int("seltab");
-			
+
 			if seltab == 2 then -- POSITIONS
-			
+
 				-- positions
 				local x0,y0,z0,x1,y1,z1,x2,y2,z2;
 				x0=tonumber(fields.x0) or 0;y0=tonumber(fields.y0) or -1;z0 = tonumber(fields.z0) or 0
 				x1=tonumber(fields.x1) or 0;y1=tonumber(fields.y1) or -1;z1 = tonumber(fields.z1) or 0
 				x2=tonumber(fields.x2) or 0;y2=tonumber(fields.y2) or 1;z2 = tonumber(fields.z2) or 0;
-			
+
 				-- did the numbers change from last time?
-				if meta:get_int("x0")~=x0 or meta:get_int("y0")~=y0 or meta:get_int("z0")~=z0 or 
-					meta:get_int("x1")~=x1 or meta:get_int("y1")~=y1 or meta:get_int("z1")~=z1 or 
+				if meta:get_int("x0")~=x0 or meta:get_int("y0")~=y0 or meta:get_int("z0")~=z0 or
+					meta:get_int("x1")~=x1 or meta:get_int("y1")~=y1 or meta:get_int("z1")~=z1 or
 					meta:get_int("x2")~=x2 or meta:get_int("y2")~=y2 or meta:get_int("z2")~=z2 then
 					-- are new numbers inside bounds?
 					if not privs.privs and (math.abs(x1)>max_range or math.abs(y1)>max_range or math.abs(z1)>max_range or math.abs(x2)>max_range or math.abs(y2)>max_range or math.abs(z2)>max_range) then
 						minetest.chat_send_player(name,"#mover: all coordinates must be between ".. -max_range .. " and " .. max_range .. ". For increased range set up positions by punching"); return
 					end
 				end
-			
+
 				--local range = meta:get_float("upgrade") or 1;	range = range * max_range;
-				
+
 				local x = x0; x0 = math.min(x,x1); x1 = math.max(x,x1);
 				local y = y0; y0 = math.min(y,y1); y1 = math.max(y,y1);
 				local z = z0; z0 = math.min(z,z1); z1 = math.max(z,z1);
-				
+
 				if minetest.is_protected({x=pos.x+x0,y=pos.y+y0,z=pos.z+z0},name) then
 					minetest.chat_send_player(name, "MOVER: position is protected. aborting.")
 					return
@@ -2218,29 +2219,29 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 					minetest.chat_send_player(name, "MOVER: position is protected. aborting.")
 					return
 				end
-				
+
 				meta:set_int("x0",x0);meta:set_int("y0",y0);meta:set_int("z0",z0);
 				meta:set_int("x1",x1);meta:set_int("y1",y1);meta:set_int("z1",z1);
 				meta:set_int("dim",(x1-x0+1)*(y1-y0+1)*(z1-z0+1))
 				meta:set_int("x2",x2);meta:set_int("y2",y2);meta:set_int("z2",z2);
-			
+
 				if fields.reverse then
 					meta:set_string("reverse",fields.reverse);
 				end
-				
+
 				if fields.inv1 then
 				 meta:set_string("inv1",fields.inv1);
 				end
-			
+
 				if fields.inv2 then
 					 meta:set_string("inv2",fields.inv2);
 				end
 
 				--notification
 				meta:set_string("infotext", "Mover block. Set up with source coordinates ".. x0 ..","..y0..","..z0.. " -> ".. x1 ..","..y1..","..z1.. " and target coord ".. x2 ..","..y2..",".. z2 .. ". Put charged battery next to it and start it with keypad/mese signal.");
-			
+
 			else -- MODE 1
-			
+
 				if fields.mode then
 					local mode = fields.mode;
 					if meta:get_string("mode")~=mode then
@@ -2248,12 +2249,12 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 						if check_mover_filter(meta:get_string("mode"), fields.prefer or "", meta:get_int("reverse")) then
 							meta:set_string("mode",fields.mode);
 						else
-							minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block") 
+							minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block")
 						end
 					end
 				end
-				
-			
+
+
 				--filter
 				local prefer = fields.prefer or "";
 				if meta:get_string("prefer")~=prefer then
@@ -2261,44 +2262,44 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 					if check_mover_filter(meta:get_string("mode"), prefer, meta:get_int("reverse")) then
 						meta:set_string("prefer",prefer);
 					else
-						minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block") 
+						minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block")
 					end
 				end
-				
+
 				--notification
 				meta:set_string("infotext", "Mover block. Mode or filter changed.");
 			end
-			
+
 			if meta:get_float("fuel")<0 then meta:set_float("fuel",0) end -- reset block
 
 			-- display battery
 			local fpos = find_and_connect_battery(pos);
-			
-			if not fpos then 
-				minetest.chat_send_player(name,"MOVER: please put battery nearby") 
+
+			if not fpos then
+				minetest.chat_send_player(name,"MOVER: please put battery nearby")
 			else
-				minetest.chat_send_player(name,"MOVER: battery found - displaying mark 1") 
+				minetest.chat_send_player(name,"MOVER: battery found - displaying mark 1")
 				machines.pos1[name] = fpos;	machines.mark_pos1(name)
 			end
-			
+
 		elseif fields.mode then
 			if not check_mover_filter(fields.mode, meta:get_string("prefer"), meta:get_string("reverse")) then
-				minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block") 
+				minetest.chat_send_player(name,"MOVER: wrong filter - must be name of existing minetest block")
 				return -- input validation
 			end
-			
+
 			meta:set_string("mode",fields.mode);
 			local form = get_mover_form(pos,player)
 			minetest.show_formspec(player:get_player_name(), "basic_machines:mover_"..minetest.pos_to_string(pos), form)
 			return
 		end
-		
-		return 
+
+		return
 	end
-	
+
 	-- KEYPAD
 	fname = "basic_machines:keypad_"
-	
+
 	if string.sub(formname,0,string.len(fname)) == fname then
 		local pos_s = string.sub(formname,string.len(fname)+1); local pos = minetest.string_to_pos(pos_s)
 		local name = player:get_player_name(); if name==nil then return end
@@ -2329,94 +2330,94 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 				"\n\nadvanced: "..
 				"\ntext replacement : Suppose keypad A is set with text \"@some @. text @!\" and there are blocks on top of keypad A with infotext '1' and '2'. Suppose we target B with A and activate A. Then text of keypad B will be set to \"some 1. text 2!\""..
 				"\nword extraction: Suppose similiar setup but now keypad A is set with text \"%1\". Then upon activation text of keypad B will be set to 1.st word of infotext";
-			
-			
+
+
 			local form = "size [8,7] textarea[0,0.1;8.5,8.5;help;KEYPAD HELP;".. minetest.formspec_escape(text).."]"
 			minetest.show_formspec(name, "basic_machines:help_keypad", form)
 			return
 		end
-		
+
 		if fields.OK == "OK" then
 			local x0,y0,z0,pass,mode;
 			x0=tonumber(fields.x0) or 0;y0=tonumber(fields.y0) or 1;z0=tonumber(fields.z0) or 0
 			pass = fields.pass or ""; mode = tonumber(fields.mode) or 1;
-			
+
 			if minetest.is_protected({x=pos.x+x0,y=pos.y+y0,z=pos.z+z0},name) then
 				minetest.chat_send_player(name, "KEYPAD: position is protected. aborting.")
 				return
 			end
-			
+
 			if not privs.privs and (math.abs(x0)>max_range or math.abs(y0)>max_range or math.abs(z0)>max_range) then
 				minetest.chat_send_player(name,"#keypad: all coordinates must be between ".. -max_range .. " and " .. max_range); return
 			end
 			meta:set_int("x0",x0);meta:set_int("y0",y0);meta:set_int("z0",z0);
-			
+
 			if fields.pass then
 				if fields.pass~="" and string.len(fields.pass)<=16 then -- dont replace password with hash which is longer - 27 chars
 					pass=minetest.get_password_hash(pos.x, pass..pos.y);pass=minetest.get_password_hash(pos.y, pass..pos.z);
-					meta:set_string("pass",pass); 
+					meta:set_string("pass",pass);
 				end
 			end
-			
+
 			if fields.text then
 				meta:set_string("text", fields.text);
 				if string.find(fields.text, "!") then minetest.log("action", string.format("%s set up keypad for message display at %s", name, minetest.pos_to_string(pos))) end
 			end
-			
+
 			meta:set_int("iter",math.min(tonumber(fields.iter) or 1,500));meta:set_int("mode",mode);
 			meta:set_string("infotext", "Punch keypad to use it.");
-			if pass~="" then 
+			if pass~="" then
 				if fields.text~="@" then
-					meta:set_string("infotext",meta:get_string("infotext").. ". Password protected."); 
+					meta:set_string("infotext",meta:get_string("infotext").. ". Password protected.");
 				else
-					meta:set_string("infotext","punch keyboard to use it."); 
+					meta:set_string("infotext","punch keyboard to use it.");
 				end
 			end
-			
+
 		end
 		return
 	end
-	
+
 	fname = "basic_machines:check_keypad_"
 	if string.sub(formname,0,string.len(fname)) == fname then
 		local pos_s = string.sub(formname,string.len(fname)+1); local pos = minetest.string_to_pos(pos_s)
 		local name = player:get_player_name(); if name==nil then return end
 		local meta = minetest.get_meta(pos)
-	
+
 		if fields.OK == "OK" then
-			
+
 			local pass;
 			pass = fields.pass or "";
-			
+
 			if meta:get_string("text")=="@" then -- keyboard mode
 				meta:set_string("input", pass);
 				meta:set_int("count",1);
 				use_keypad(pos,machines_TTL,0);
 				return
 			end
-					
-			
+
+
 			pass=minetest.get_password_hash(pos.x, pass..pos.y);pass=minetest.get_password_hash(pos.y, pass..pos.z);
-			
+
 			if pass~=meta:get_string("pass") then
 				minetest.chat_send_player(name,"ACCESS DENIED. WRONG PASSWORD.")
 				return
 			end
 		minetest.chat_send_player(name,"ACCESS GRANTED.")
-		
+
 		if meta:get_int("count")<=0 then -- only accept new operation requests if idle
-			meta:set_int("count",meta:get_int("iter")); 
+			meta:set_int("count",meta:get_int("iter"));
 			meta:set_int("active_repeats",0);
 			use_keypad(pos,machines_TTL,0)
-		else 
-			meta:set_int("count",0); 
+		else
+			meta:set_int("count",0);
 			meta:set_string("infotext","operation aborted by user. punch to activate.") -- reset
 		end
-		
+
 		return
 		end
 	end
-	
+
 	-- DETECTOR
 	local fname = "basic_machines:detector_"
 	if string.sub(formname,0,string.len(fname)) == fname then
@@ -2425,32 +2426,32 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 		local meta = minetest.get_meta(pos)
 		local privs = minetest.get_player_privs(player:get_player_name());
 		if (minetest.is_protected(pos,name) and not privs.privs) or not fields then return end -- only builder
-		
+
 		--minetest.chat_send_all("formname " .. formname .. " fields " .. dump(fields))
-		
+
 		if fields.help == "help" then
 			local text = "SETUP: right click or punch and follow chat instructions. With detector you can detect nodes, objects, players, or items inside inventories."..
 			"If detector activates it will trigger machine at target position.\n\nThere are 4 modes of operation - node/player/object/inventory detection. Inside node/player/object "..
 			"write node/player/object name. If you detect players/objects you can specify range of detection. If you want detector to activate target precisely when its not triggered set NOT to 1\n\n"..
-			"For example, to detect empty space write air, to detect tree write default:tree, to detect ripe wheat write farming:wheat_8, for flowing water write default:water_flowing ... ".. 
+			"For example, to detect empty space write air, to detect tree write default:tree, to detect ripe wheat write farming:wheat_8, for flowing water write default:water_flowing ... "..
 			"If source position is chest it will look into it and check if there are items inside. If mode is inventory it will check for items in specified inventory of source node."..
 			"\n\nADVANCED: you can select second source and then select AND/OR from the right top dropdown list to do logical operations. You can also filter output signal:\n -2=only OFF,-1=NOT/0/1=normal,2=only ON, 3 only if changed"..
 			" 4 = if target keypad set its text to detected object name" ;
 			local form = "size [5.5,5.5] textarea[0,0;6,7;help;DETECTOR HELP;".. text.."]"
 			minetest.show_formspec(name, "basic_machines:help_detector", form)
 		end
-		
+
 		if fields.OK == "OK" then
-			
-			
+
+
 			local x0,y0,z0,x1,y1,z1,x2,y2,z2,r,node,NOT;
 			x0=tonumber(fields.x0) or 0;y0=tonumber(fields.y0) or 0;z0=tonumber(fields.z0) or 0
 			x1=tonumber(fields.x1) or 0;y1=tonumber(fields.y1) or 0;z1=tonumber(fields.z1) or 0
 			x2=tonumber(fields.x2) or 0;y2=tonumber(fields.y2) or 0;z2=tonumber(fields.z2) or 0
 			r=tonumber(fields.r) or 1;
 			NOT = tonumber(fields.NOT) or 0;
-			
-			
+
+
 			if minetest.is_protected({x=pos.x+x0,y=pos.y+y0,z=pos.z+z0},name) then
 				minetest.chat_send_player(name, "DETECTOR: position is protected. aborting.")
 				return
@@ -2465,19 +2466,19 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 			if not privs.privs and (math.abs(x0)>max_range or math.abs(y0)>max_range or math.abs(z0)>max_range or math.abs(x1)>max_range or math.abs(y1)>max_range or math.abs(z1)>max_range) then
 				minetest.chat_send_player(name,"#detector: all coordinates must be between ".. -max_range .. " and " .. max_range); return
 			end
-			
+
 			if fields.inv1 then
-				 meta:set_string("inv1",fields.inv1); 
+				 meta:set_string("inv1",fields.inv1);
 			end
 
 			meta:set_int("x0",x0);meta:set_int("y0",y0);meta:set_int("z0",z0);
 			meta:set_int("x1",x1);meta:set_int("y1",y1);meta:set_int("z1",z1);
 			meta:set_int("x2",x2);meta:set_int("y2",y2);meta:set_int("z2",z2);
-			
+
 			meta:set_int("r",math.min(r,10));
 			meta:set_int("NOT",NOT);
 			meta:set_string("node",fields.node or "");
-			
+
 			local mode = fields.mode or "node";
 			meta:set_string("mode",mode);
 			local op = fields.op or "";
@@ -2487,7 +2488,7 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 		return
 	end
 
-	
+
 	-- DISTRIBUTOR
 	local fname = "basic_machines:distributor_"
 	if string.sub(formname,0,string.len(fname)) == fname then
@@ -2497,21 +2498,21 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 		local privs = minetest.get_player_privs(player:get_player_name());
 		if (minetest.is_protected(pos,name) and not privs.privs) or not fields then return end -- only builder
 		--minetest.chat_send_all("formname " .. formname .. " fields " .. dump(fields))
-		
+
 		if fields.OK == "OK" then
-			
+
 			local posmode = (meta:get_int("view") == 0);
 			local posf = {}; local active = {};
 			local n = meta:get_int("n");
 			for i = 1,n do
 				posf[i]={x=tonumber(fields["x"..i]) or meta:get_int("x"..i),y=tonumber(fields["y"..i]) or meta:get_int("y"..i),z=tonumber(fields["z"..i]) or meta:get_int("z"..i)};
 				active[i]=tonumber(fields["active"..i]) or 0;
-			
+
 				if (not (privs.privs) and math.abs(posf[i].x)>2*max_range or math.abs(posf[i].y)>2*max_range or math.abs(posf[i].z)>2*max_range) then
-					minetest.chat_send_player(name,"#distributor: all coordinates must be between ".. -2*max_range .. " and " .. 2*max_range); 
+					minetest.chat_send_player(name,"#distributor: all coordinates must be between ".. -2*max_range .. " and " .. 2*max_range);
 					return
 				end
-			
+
 				if posmode then meta:set_int("x"..i,posf[i].x);meta:set_int("y"..i,posf[i].y);meta:set_int("z"..i,posf[i].z); end
 				if posf[i].x==0 and posf[i].y==0 and posf[i].z==0 then
 					meta:set_int("active"..i,0); -- no point in activating itself
@@ -2523,30 +2524,30 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 				end
 			end
 		end
-		
+
 		if fields["view"] then -- change view mode
 			meta:set_int("view",1-meta:get_int("view"))
 			local form = get_distributor_form(pos,player)
 			minetest.show_formspec(player:get_player_name(), "basic_machines:distributor_"..minetest.pos_to_string(pos), form)
 			return
 		end
-		
+
 		if fields["scan"] then -- scan for connectable nodes
 			local connectables = basic_machines.connectables;
 			local x1 = (meta:get_int("x1") or 0)+pos.x;
 			local y1 = (meta:get_int("y1") or 0)+pos.y;
 			local z1 = (meta:get_int("z1") or 0)+pos.z;
-			
+
 			local x2 = (meta:get_int("x2") or 0)+pos.x;
 			local y2 = (meta:get_int("y2") or 0)+pos.y;
 			local z2 = (meta:get_int("z2") or 0)+pos.z;
-			
+
 			if x1>x2 then x1,x2 = x2,x1 end
 			if y1>y2 then y1,y2 = y2,y1 end
 			if z1>z2 then z1,z2 = z2,z1 end
-			
+
 			local count = 0;
-			
+
 			for x = x1,x2 do
 				for y = y1,y2 do
 					for z = z1,z2 do
@@ -2563,11 +2564,11 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 				end
 			end
 			meta:set_int("n", count)
-			minetest.chat_send_player(name,"[DISTRIBUTOR] connected " .. count .. " targets."); 
+			minetest.chat_send_player(name,"[DISTRIBUTOR] connected " .. count .. " targets.");
 			return
 		end
-		
-		
+
+
 		if fields["ADD"] then
 			local n = meta:get_int("n");
 			if n<16 then meta:set_int("n",n+1);	end -- max 16 outputs
@@ -2575,51 +2576,51 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 			minetest.show_formspec(player:get_player_name(), "basic_machines:distributor_"..minetest.pos_to_string(pos), form)
 			return
 		end
-		
+
 		-- SHOWING TARGET
 		local j=-1;local n = meta:get_int("n");
 		for i = 1,n do if fields["SHOW"..i] then j = i end end
-		
+
 		--show j-th point
-		if j>0 then 
+		if j>0 then
 			local posf={x=meta:get_int("x"..j) or 0,y=meta:get_int("y"..j) or 0,z=meta:get_int("z"..j) or 0};
 			machines.pos1[player:get_player_name()] = {x=posf.x+pos.x,y=posf.y+pos.y,z=posf.z+pos.z};
 			machines.mark_pos1(player:get_player_name())
 			return;
 		end
-		
+
 		--SETUP TARGET
 		j=-1;
 		for i = 1,n do if fields["SET"..i] then j = i end end
 		-- set up j-th point
-		if j>0 then 
+		if j>0 then
 			punchset[name].node = "basic_machines:distributor";
 			punchset[name].state = j
 			punchset[name].pos = pos;
-			minetest.chat_send_player(name,"[DISTRIBUTOR] punch the position to set target "..j); 
+			minetest.chat_send_player(name,"[DISTRIBUTOR] punch the position to set target "..j);
 			return;
 		end
-		
+
 		-- REMOVE TARGET
 		if n>0 then
 			j=-1;
 			for i = 1,n do if fields["X"..i] then j = i end end
 			-- remove j-th point
-			if j>0 then 
+			if j>0 then
 				for i=j,n-1 do
 					meta:set_int("x"..i, meta:get_int("x"..(i+1)))
 					meta:set_int("y"..i, meta:get_int("y"..(i+1)))
 					meta:set_int("z"..i, meta:get_int("z"..(i+1)))
 					meta:set_int("active"..i, meta:get_int("active"..(i+1)))
 				end
-				
+
 				meta:set_int("n",n-1);
 				local form = get_distributor_form(pos,player)
 				minetest.show_formspec(player:get_player_name(), "basic_machines:distributor_"..minetest.pos_to_string(pos), form)
 				return;
 			end
 		end
-		
+
 		if fields.help == "help" then
 			local text = "SETUP: to select target nodes for activation click SET then click target node.\n"..
 			"You can add more targets with ADD. To see where target node is click SHOW button next to it.\n\n"..
@@ -2632,14 +2633,14 @@ minetest.register_on_player_receive_fields(function(player,formname,fields)
 			"ADVANCED: you can use distributor as an event handler - it listens to events like interact attempts and chat around distributor.\n"..
 			"First you need to place distributor at position (x,y,z) in world, such that the coordinates are of the form (20*i,20*j+1,20*k) for\n"..
 			"some integers i,j,k. Then you need to configure first row of numbers in distributor:\n"..
-			"by putting 0 as MODE it will start to listen. First number x = 0/1 controls if node listens to failed interact attempts around it, second\n".. 
+			"by putting 0 as MODE it will start to listen. First number x = 0/1 controls if node listens to failed interact attempts around it, second\n"..
 			"number y= -1/0/1 controls listening to chat (-1 additionaly mutes chat)";
 			local form = "size [7.5,5.5] textarea[0,0.1;8,7;help;DISTRIBUTOR HELP;".. text.."]"
 			minetest.show_formspec(name, "basic_machines:help_distributor", form)
 		end
-		
+
 	end
-	
+
 end)
 
 


### PR DESCRIPTION
I caused a crash in another server by accidentally setting up a reversed digger with a filter using two blocks instead of one. This change makes the filter invalid if it has a space in it, making only single item filters valid.